### PR TITLE
Feature/d3 asim 3633

### DIFF
--- a/gsy_framework/constants_limits.py
+++ b/gsy_framework/constants_limits.py
@@ -96,9 +96,6 @@ class ConstSettings:
         FINAL_SELLING_RATE_LIMIT = RangeLimit(0, 10000)
         # Min allowed battery SOC, range is [0, 100] %.
         MIN_ALLOWED_SOC = 10
-        # Controls whether energy is sold only on the most expensive market, default is
-        # to sell to all markets
-        SELL_ON_MOST_EXPENSIVE_MARKET = False
 
         # Controls the energy loss of the storage over time#
         # LOSS_FUNCTION = 1 ==> relative loss

--- a/tests/test_user_profile.py
+++ b/tests/test_user_profile.py
@@ -96,7 +96,7 @@ class TestReadUserProfile(unittest.TestCase):
             datetime(2021, 2, 12, 0, 30, 0): 0.1
         })
 
-    def test_correct_time_expansion_read_arbitrary_profile(self):
+    def test_read_arbitrary_profile_returns_profile_with_correct_time_expansion(self):
         market_maker_rate = 30
         if GlobalConfig.IS_CANARY_NETWORK:
             GlobalConfig.sim_duration = duration(hours=3)
@@ -121,4 +121,6 @@ class TestReadUserProfile(unittest.TestCase):
             GlobalConfig.FUTURE_MARKET_DURATION_HOURS = 24
             GlobalConfig.sim_duration = duration(hours=1)
             mmr = read_arbitrary_profile(InputProfileTypes.IDENTITY, market_maker_rate)
-            assert (list(mmr.keys())[-1] - today(tz=TIME_ZONE)).days == 1
+            time_diff = list(mmr.keys())[-1] - today(tz=TIME_ZONE)
+            assert time_diff.hours == 0
+            assert time_diff.days == 1


### PR DESCRIPTION
- Removed deprecated parameter SELL_ON_MOST_EXPENSIVE_MARKET
- Adapted generate_market_slot_list method to include the future market time slots, in order to correctly expand the profiles to take into account future markets too. 