### PR TITLE
 Rename BidOfferMatch dataclass to 'OrdersMatch'

### DIFF
--- a/gsy_framework/constants_limits.py
+++ b/gsy_framework/constants_limits.py
@@ -22,7 +22,7 @@ from datetime import date, datetime
 
 from pendulum import duration, instance
 
-from gsy_framework.enums import BidOfferMatchAlgoEnum, SpotMarketTypeEnum
+from gsy_framework.enums import OrdersMatchAlgoEnum, SpotMarketTypeEnum
 
 RangeLimit = namedtuple('RangeLimit', ('min', 'max'))
 RateRange = namedtuple('RateRange', ('initial', 'final'))
@@ -166,7 +166,7 @@ class ConstSettings:
         MARKET_TYPE = SpotMarketTypeEnum.ONE_SIDED.value
         MARKET_TYPE_LIMIT = RangeLimit(1, 2)
 
-        BID_OFFER_MATCH_TYPE = BidOfferMatchAlgoEnum.PAY_AS_BID.value
+        BID_OFFER_MATCH_TYPE = OrdersMatchAlgoEnum.PAY_AS_BID.value
         BID_OFFER_MATCH_TYPE_LIMIT = RangeLimit(1, 3)
 
         # Pay as clear offer and bid rate/energy aggregation algorithm

--- a/gsy_framework/constants_limits.py
+++ b/gsy_framework/constants_limits.py
@@ -46,7 +46,7 @@ class ConstSettings:
         SETUP_FILE_PATH = None  # Default path of the available setup files
         EXPORT_DEVICE_PLOTS = True
         EXPORT_ENERGY_TRADE_PROFILE_HR = False
-        EXPORT_OFFER_BID_TRADE_HR = False
+        EXPORT_ORDERS_TRADE_HR = False
         # Boolean flag which forces d3a to run in real-time
         RUN_REAL_TIME = False
         # Boolean flag which forces d3a to dispatch events via redis channels
@@ -166,8 +166,8 @@ class ConstSettings:
         MARKET_TYPE = SpotMarketTypeEnum.ONE_SIDED.value
         MARKET_TYPE_LIMIT = RangeLimit(1, 2)
 
-        BID_OFFER_MATCH_TYPE = OrdersMatchAlgoEnum.PAY_AS_BID.value
-        BID_OFFER_MATCH_TYPE_LIMIT = RangeLimit(1, 3)
+        ORDERS_MATCH_TYPE = OrdersMatchAlgoEnum.PAY_AS_BID.value
+        ORDERS_MATCH_TYPE_LIMIT = RangeLimit(1, 3)
 
         # Pay as clear offer and bid rate/energy aggregation algorithm
         # Default value 1 stands for line sweep algorithm

--- a/gsy_framework/data_classes.py
+++ b/gsy_framework/data_classes.py
@@ -289,7 +289,7 @@ class Bid(BaseOrder):
 
 
 @dataclass
-class TradeOrderInfo:
+class TradeOrdersInfo:
     """Class that contains information about the original bid or offer."""
     original_bid_rate: float
     propagated_bid_rate: float
@@ -302,10 +302,10 @@ class TradeOrderInfo:
         return json.dumps(asdict(self), default=json_datetime_serializer)
 
     @staticmethod
-    def from_json(trade_order_info: str) -> "TradeOrderInfo":
-        """Return TradeOrderInfo object from json representation."""
-        info_dict = json.loads(trade_order_info)
-        return TradeOrderInfo(**info_dict)
+    def from_json(trade_orders_info: str) -> "TradeOrdersInfo":
+        """Return TradeOrdersInfo object from json representation."""
+        info_dict = json.loads(trade_orders_info)
+        return TradeOrdersInfo(**info_dict)
 
 
 class Trade:
@@ -313,7 +313,7 @@ class Trade:
     def __init__(self, id: str, creation_time: DateTime, order: Union[Offer, Bid],
                  seller: str, buyer: str, residual: Optional[Union[Offer, Bid]] = None,
                  already_tracked: bool = False,
-                 trade_orders_info: Optional[TradeOrderInfo] = None,
+                 trade_orders_info: Optional[TradeOrdersInfo] = None,
                  seller_origin: Optional[str] = None, buyer_origin: Optional[str] = None,
                  fee_price: Optional[float] = None, seller_origin_id: Optional[str] = None,
                  buyer_origin_id: Optional[str] = None, seller_id: Optional[str] = None,
@@ -380,7 +380,7 @@ class Trade:
             trade_dict["time_slot"] = str_to_pendulum_datetime(trade_dict["time_slot"])
         if trade_dict.get("trade_orders_info"):
             trade_dict["trade_orders_info"] = (
-                TradeOrderInfo.from_json(trade_dict["trade_orders_info"]))
+                TradeOrdersInfo.from_json(trade_dict["trade_orders_info"]))
         return Trade(**trade_dict)
 
     @property

--- a/gsy_framework/data_classes.py
+++ b/gsy_framework/data_classes.py
@@ -40,7 +40,7 @@ def json_datetime_serializer(datetime_obj: DateTime) -> Optional[str]:
     return None
 
 
-class BaseBidOffer:
+class BaseOrder:
     """Base class defining shared functionality of Bid and Offer market structures."""
     def __init__(self, id: str, creation_time: DateTime, price: float, energy: float,
                  original_price: Optional[float] = None, time_slot: DateTime = None,
@@ -115,7 +115,7 @@ class BaseBidOffer:
         assert False, "the type member needs to be set to one of ('Bid', 'Offer')."
 
 
-class Offer(BaseBidOffer):
+class Offer(BaseOrder):
     """Offer class"""
     def __init__(self, id: str, creation_time: DateTime, price: float,
                  energy: float, seller: str, original_price: Optional[float] = None,
@@ -202,7 +202,7 @@ class Offer(BaseBidOffer):
                      time_slot=offer.time_slot)
 
 
-class Bid(BaseBidOffer):
+class Bid(BaseOrder):
     "Bid class."
     def __init__(self, id: str, creation_time: DateTime, price: float,
                  energy: float, buyer: str,
@@ -369,9 +369,9 @@ class Trade:
     def from_json(cls, trade_string) -> "Trade":
         """De-serialize trade from json string."""
         trade_dict = json.loads(trade_string)
-        trade_dict["offer_bid"] = BaseBidOffer.from_json(trade_dict["offer_bid"])
+        trade_dict["offer_bid"] = BaseOrder.from_json(trade_dict["offer_bid"])
         if trade_dict.get("residual"):
-            trade_dict["residual"] = BaseBidOffer.from_json(trade_dict["residual"])
+            trade_dict["residual"] = BaseOrder.from_json(trade_dict["residual"])
         if trade_dict.get("creation_time"):
             trade_dict["creation_time"] = str_to_pendulum_datetime(trade_dict["creation_time"])
         else:
@@ -484,14 +484,14 @@ class OrdersMatch:
 
     @classmethod
     def from_dict(cls, bid_offer_match: Dict) -> Optional["OrdersMatch"]:
-        """Receive a serializable dict of BidOfferMatch and return a BidOfferMatch object."""
+        """Receive a serializable dict of OrdersMatch and return a OrdersMatch object."""
         if cls.is_valid_dict(bid_offer_match):
             return OrdersMatch(**bid_offer_match)
         return None
 
     @classmethod
     def is_valid_dict(cls, bid_offer_match: Dict) -> bool:
-        """Check whether a serialized dict can be a valid BidOfferMatch instance."""
+        """Check whether a serialized dict can be a valid OrdersMatch instance."""
         is_valid = True
         if len(bid_offer_match.keys()) != len(cls.__annotations__.keys()):
             is_valid = False

--- a/gsy_framework/data_classes.py
+++ b/gsy_framework/data_classes.py
@@ -462,7 +462,7 @@ class BalancingTrade(Trade):
 
 
 @dataclass
-class BidOfferMatch:
+class OrdersMatch:
     """Representation of a market match."""
     market_id: str
     time_slot: str
@@ -483,10 +483,10 @@ class BidOfferMatch:
         }
 
     @classmethod
-    def from_dict(cls, bid_offer_match: Dict) -> Optional["BidOfferMatch"]:
+    def from_dict(cls, bid_offer_match: Dict) -> Optional["OrdersMatch"]:
         """Receive a serializable dict of BidOfferMatch and return a BidOfferMatch object."""
         if cls.is_valid_dict(bid_offer_match):
-            return BidOfferMatch(**bid_offer_match)
+            return OrdersMatch(**bid_offer_match)
         return None
 
     @classmethod

--- a/gsy_framework/data_classes.py
+++ b/gsy_framework/data_classes.py
@@ -289,7 +289,7 @@ class Bid(BaseOrder):
 
 
 @dataclass
-class TradeBidOfferInfo:
+class TradeOrderInfo:
     """Class that contains information about the original bid or offer."""
     original_bid_rate: float
     propagated_bid_rate: float
@@ -302,10 +302,10 @@ class TradeBidOfferInfo:
         return json.dumps(asdict(self), default=json_datetime_serializer)
 
     @staticmethod
-    def from_json(trade_bid_offer_info: str) -> "TradeBidOfferInfo":
-        """Return TradeBidOfferInfo object from json representation."""
+    def from_json(trade_bid_offer_info: str) -> "TradeOrderInfo":
+        """Return TradeOrderInfo object from json representation."""
         info_dict = json.loads(trade_bid_offer_info)
-        return TradeBidOfferInfo(**info_dict)
+        return TradeOrderInfo(**info_dict)
 
 
 class Trade:
@@ -313,7 +313,7 @@ class Trade:
     def __init__(self, id: str, creation_time: DateTime, offer_bid: Union[Offer, Bid],
                  seller: str, buyer: str, residual: Optional[Union[Offer, Bid]] = None,
                  already_tracked: bool = False,
-                 offer_bid_trade_info: Optional[TradeBidOfferInfo] = None,
+                 offer_bid_trade_info: Optional[TradeOrderInfo] = None,
                  seller_origin: Optional[str] = None, buyer_origin: Optional[str] = None,
                  fee_price: Optional[float] = None, seller_origin_id: Optional[str] = None,
                  buyer_origin_id: Optional[str] = None, seller_id: Optional[str] = None,
@@ -380,7 +380,7 @@ class Trade:
             trade_dict["time_slot"] = str_to_pendulum_datetime(trade_dict["time_slot"])
         if trade_dict.get("offer_bid_trade_info"):
             trade_dict["offer_bid_trade_info"] = (
-                TradeBidOfferInfo.from_json(trade_dict["offer_bid_trade_info"]))
+                TradeOrderInfo.from_json(trade_dict["offer_bid_trade_info"]))
         return Trade(**trade_dict)
 
     @property

--- a/gsy_framework/enums.py
+++ b/gsy_framework/enums.py
@@ -1,7 +1,7 @@
 from enum import Enum
 
 
-class BidOfferMatchAlgoEnum(Enum):
+class OrdersMatchAlgoEnum(Enum):
     PAY_AS_BID = 1
     PAY_AS_CLEAR = 2
     EXTERNAL = 3

--- a/gsy_framework/matching_algorithms/abstract_matching_algorithm.py
+++ b/gsy_framework/matching_algorithms/abstract_matching_algorithm.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Dict, List
 
-from gsy_framework.data_classes import BidOfferMatch
+from gsy_framework.data_classes import OrdersMatch
 
 
 class BaseMatchingAlgorithm(ABC):
@@ -9,11 +9,11 @@ class BaseMatchingAlgorithm(ABC):
     @classmethod
     @abstractmethod
     def get_matches_recommendations(
-            cls, matching_data: Dict) -> List[BidOfferMatch.serializable_dict]:
+            cls, matching_data: Dict) -> List[OrdersMatch.serializable_dict]:
         """Calculate and return matches recommendations.
 
         Args:
             matching_data: {market_uuid: {"offers": [...], "bids": [...], "current_time":"",...}}
 
-        Returns: List[BidOfferMatch.serializable_dict()]
+        Returns: List[OrdersMatch.serializable_dict()]
         """

--- a/gsy_framework/matching_algorithms/pay_as_bid_matching_algorithm.py
+++ b/gsy_framework/matching_algorithms/pay_as_bid_matching_algorithm.py
@@ -1,7 +1,7 @@
 from typing import Dict, List
 
 from gsy_framework.constants_limits import FLOATING_POINT_TOLERANCE
-from gsy_framework.data_classes import BidOfferMatch
+from gsy_framework.data_classes import OrdersMatch
 from gsy_framework.matching_algorithms import BaseMatchingAlgorithm
 from gsy_framework.utils import sort_list_of_dicts_by_attribute
 
@@ -37,7 +37,7 @@ class PayAsBidMatchingAlgorithm(BaseMatchingAlgorithm):
                             already_selected_bids.add(bid.get("id"))
                             selected_energy = min(bid.get("energy"), offer.get("energy"))
                             bid_offer_pairs.append(
-                                BidOfferMatch(
+                                OrdersMatch(
                                     market_id=market_id,
                                     time_slot=time_slot,
                                     bids=[bid], offers=[offer],

--- a/gsy_framework/matching_algorithms/pay_as_bid_matching_algorithm.py
+++ b/gsy_framework/matching_algorithms/pay_as_bid_matching_algorithm.py
@@ -17,7 +17,7 @@ class PayAsBidMatchingAlgorithm(BaseMatchingAlgorithm):
 
     @classmethod
     def get_matches_recommendations(cls, matching_data: Dict) -> List:
-        bid_offer_pairs = []
+        orders_pairs = []
         for market_id, time_slot_data in matching_data.items():
             for time_slot, data in time_slot_data.items():
                 bids = data.get("bids")
@@ -36,7 +36,7 @@ class PayAsBidMatchingAlgorithm(BaseMatchingAlgorithm):
                                 "energy_rate")) <= FLOATING_POINT_TOLERANCE:
                             already_selected_bids.add(bid.get("id"))
                             selected_energy = min(bid.get("energy"), offer.get("energy"))
-                            bid_offer_pairs.append(
+                            orders_pairs.append(
                                 OrdersMatch(
                                     market_id=market_id,
                                     time_slot=time_slot,
@@ -44,4 +44,4 @@ class PayAsBidMatchingAlgorithm(BaseMatchingAlgorithm):
                                     selected_energy=selected_energy,
                                     trade_rate=bid.get("energy_rate")).serializable_dict())
                             break
-        return bid_offer_pairs
+        return orders_pairs

--- a/gsy_framework/matching_algorithms/pay_as_clear_matching_algorithm.py
+++ b/gsy_framework/matching_algorithms/pay_as_clear_matching_algorithm.py
@@ -25,7 +25,7 @@ from typing import List, Dict, Union
 from pendulum import DateTime
 
 from gsy_framework.constants_limits import ConstSettings
-from gsy_framework.data_classes import MarketClearingState, Clearing, BidOfferMatch
+from gsy_framework.data_classes import MarketClearingState, Clearing, OrdersMatch
 from gsy_framework.matching_algorithms import BaseMatchingAlgorithm
 from gsy_framework.utils import sort_list_of_dicts_by_attribute, add_or_create_key
 
@@ -197,9 +197,9 @@ class PayAsClearMatchingAlgorithm(BaseMatchingAlgorithm):
                     offers.insert(0, offer)
                     # Save the matching
                     bid_offer_matches.append(
-                        BidOfferMatch(market_id=market_id, time_slot=time_slot,
-                                      bids=[bid], selected_energy=bid_energy,
-                                      offers=[offer], trade_rate=clearing_rate).serializable_dict()
+                        OrdersMatch(market_id=market_id, time_slot=time_slot,
+                                    bids=[bid], selected_energy=bid_energy,
+                                    offers=[offer], trade_rate=clearing_rate).serializable_dict()
                     )
                     # Update total clearing energy
                     clearing_energy -= bid_energy
@@ -209,7 +209,7 @@ class PayAsClearMatchingAlgorithm(BaseMatchingAlgorithm):
                     # Offer is exhausted by the bid. More offers are needed to cover the bid.
                     # Save the matching offer to accept later
                     bid_offer_matches.append(
-                        BidOfferMatch(
+                        OrdersMatch(
                             market_id=market_id, time_slot=time_slot,
                             bids=[bid], selected_energy=offer_energy,
                             offers=[offer], trade_rate=clearing_rate).serializable_dict()

--- a/gsy_framework/matching_algorithms/pay_as_clear_matching_algorithm.py
+++ b/gsy_framework/matching_algorithms/pay_as_clear_matching_algorithm.py
@@ -99,12 +99,12 @@ class PayAsClearMatchingAlgorithm(BaseMatchingAlgorithm):
                 return Clearing(rate, cumulative_bids[rate])
 
     @staticmethod
-    def _accumulated_energy_per_rate(orderss: List[Dict]) -> OrderedDict:
+    def _accumulated_energy_per_rate(orders: List[Dict]) -> OrderedDict:
         """Return an ordered dict with with key as energy rate and value as accumulated
         energy at that point"""
         energy_sum = 0
         accumulated = OrderedDict()
-        for orders in orderss:
+        for orders in orders:
             energy_sum += orders["energy"]
             accumulated[orders["energy_rate"]] = energy_sum
         return accumulated

--- a/gsy_framework/settings_validators.py
+++ b/gsy_framework/settings_validators.py
@@ -92,11 +92,11 @@ def validate_global_settings(settings: Dict) -> None:
         raise GSySettingsException("Invalid value for relative_std_from_forecast_percent "
                                    f"({settings['relative_std_from_forecast_percent']}).")
 
-    if ("bid_offer_match_algo" in settings
-            and not ConstSettings.IAASettings.BID_OFFER_MATCH_TYPE_LIMIT[0]
-            <= settings["bid_offer_match_algo"]
-            <= ConstSettings.IAASettings.BID_OFFER_MATCH_TYPE_LIMIT[1]):
-        raise GSySettingsException(f"Invalid value ({settings['bid_offer_match_algo']}) "
+    if ("orders_match_algo" in settings
+            and not ConstSettings.IAASettings.ORDERS_MATCH_TYPE_LIMIT[0]
+            <= settings["orders_match_algo"]
+            <= ConstSettings.IAASettings.ORDERS_MATCH_TYPE_LIMIT[1]):
+        raise GSySettingsException(f"Invalid value ({settings['orders_match_algo']}) "
                                    "for bid offer match algo.")
 
 

--- a/gsy_framework/settings_validators.py
+++ b/gsy_framework/settings_validators.py
@@ -93,9 +93,9 @@ def validate_global_settings(settings: Dict) -> None:
                                    f"({settings['relative_std_from_forecast_percent']}).")
 
     if ("orders_match_algo" in settings
-            and not ConstSettings.IAASettings.ORDERS_MATCH_TYPE_LIMIT[0]
+            and not ConstSettings.IAASettings.ORDERS_MATCH_TYPE_LIMIT.min
             <= settings["orders_match_algo"]
-            <= ConstSettings.IAASettings.ORDERS_MATCH_TYPE_LIMIT[1]):
+            <= ConstSettings.IAASettings.ORDERS_MATCH_TYPE_LIMIT.max):
         raise GSySettingsException(f"Invalid value ({settings['orders_match_algo']}) "
                                    "for bid offer match algo.")
 

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -28,7 +28,7 @@ import pytest
 from pendulum import DateTime, datetime
 
 from gsy_framework.data_classes import (
-    BidOfferMatch, BaseBidOffer, Offer, Bid, json_datetime_serializer,
+    OrdersMatch, BaseBidOffer, Offer, Bid, json_datetime_serializer,
     TradeBidOfferInfo, Trade, BalancingOffer, BalancingTrade, Clearing,
     MarketClearingState)
 from gsy_framework.utils import datetime_to_string_incl_seconds
@@ -51,7 +51,7 @@ class TestBidOfferMatch:
     @staticmethod
     def test_serializable_dict():
         """Test the serializable_dict method of BidOfferMatch dataclass."""
-        bid_offer_match = BidOfferMatch(
+        bid_offer_match = OrdersMatch(
             market_id="market_id",
             time_slot="2021-10-06T12:00",
             bids=[{"type": "bid"}],
@@ -75,7 +75,7 @@ class TestBidOfferMatch:
                            "offers": [{"type": "offer"}],
                            "selected_energy": 1,
                            "trade_rate": 1}
-        assert BidOfferMatch.is_valid_dict(bid_offer_match)
+        assert OrdersMatch.is_valid_dict(bid_offer_match)
 
         # Key does not exist
         bid_offer_match = {"market_id": "market_id",
@@ -84,7 +84,7 @@ class TestBidOfferMatch:
                            "offers": [{"type": "offer"}],
                            "selected_energy": 1,
                            }
-        assert not BidOfferMatch.is_valid_dict(bid_offer_match)
+        assert not OrdersMatch.is_valid_dict(bid_offer_match)
 
         # Wrong type
         bid_offer_match = {"market_id": "market_id",
@@ -93,7 +93,7 @@ class TestBidOfferMatch:
                            "offers": [{"type": "offer"}],
                            "selected_energy": 1,
                            "trade_rate": ""}
-        assert not BidOfferMatch.is_valid_dict(bid_offer_match)
+        assert not OrdersMatch.is_valid_dict(bid_offer_match)
 
     @staticmethod
     def test_from_dict():
@@ -104,7 +104,7 @@ class TestBidOfferMatch:
                          "offers": [{"type": "offer"}],
                          "selected_energy": 1,
                          "trade_rate": 1}
-        bid_offer_match = BidOfferMatch.from_dict(expected_dict)
+        bid_offer_match = OrdersMatch.from_dict(expected_dict)
         assert bid_offer_match.market_id == expected_dict["market_id"]
         assert bid_offer_match.time_slot == expected_dict["time_slot"]
         assert bid_offer_match.bids == expected_dict["bids"]

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -29,7 +29,7 @@ from pendulum import DateTime, datetime
 
 from gsy_framework.data_classes import (
     OrdersMatch, BaseOrder, Offer, Bid, json_datetime_serializer,
-    TradeBidOfferInfo, Trade, BalancingOffer, BalancingTrade, Clearing,
+    TradeOrderInfo, Trade, BalancingOffer, BalancingTrade, Clearing,
     MarketClearingState)
 from gsy_framework.utils import datetime_to_string_incl_seconds
 
@@ -450,10 +450,10 @@ class TestBid:
                 ("creation_time", "rate [ct./kWh]", "energy [kWh]", "price [ct.]", "buyer"))
 
 
-class TestTradeBidOfferInfo:
+class TestTradeOrderInfo:
     @staticmethod
     def test_to_json_string():
-        trade_bid_offer_info = TradeBidOfferInfo(
+        trade_bid_offer_info = TradeOrderInfo(
             1, 1, 1, 1, 1
         )
         assert (trade_bid_offer_info.to_json_string() ==
@@ -461,11 +461,11 @@ class TestTradeBidOfferInfo:
 
     @staticmethod
     def test_from_json():
-        trade_bid_offer_info = TradeBidOfferInfo(
+        trade_bid_offer_info = TradeOrderInfo(
             1, 1, 1, 1, 1
         )
         trade_bid_offer_info_json = trade_bid_offer_info.to_json_string()
-        assert (TradeBidOfferInfo.from_json(trade_bid_offer_info_json) ==
+        assert (TradeOrderInfo.from_json(trade_bid_offer_info_json) ==
                 trade_bid_offer_info)
 
 
@@ -512,7 +512,7 @@ class TestTrade:
         assert json.loads(trade.to_json_string()).get("residual") is not None
 
         # Test the offer_bid_trade_info check
-        trade.offer_bid_trade_info = TradeBidOfferInfo(1, 2, 3, 4, 5)
+        trade.offer_bid_trade_info = TradeOrderInfo(1, 2, 3, 4, 5)
         trade_dict["offer_bid_trade_info"] = (
             deepcopy(trade.offer_bid_trade_info).to_json_string())
         assert (trade.to_json_string() ==
@@ -524,7 +524,7 @@ class TestTrade:
             **self.initial_data
         )
         trade.residual = deepcopy(trade.offer_bid)
-        trade.offer_bid_trade_info = TradeBidOfferInfo(
+        trade.offer_bid_trade_info = TradeOrderInfo(
             1, 1, 1, 1, 1
         )
         assert Trade.from_json(trade.to_json_string()) == trade

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -29,7 +29,7 @@ from pendulum import DateTime, datetime
 
 from gsy_framework.data_classes import (
     OrdersMatch, BaseOrder, Offer, Bid, json_datetime_serializer,
-    TradeOrderInfo, Trade, BalancingOffer, BalancingTrade, Clearing,
+    TradeOrdersInfo, Trade, BalancingOffer, BalancingTrade, Clearing,
     MarketClearingState)
 from gsy_framework.utils import datetime_to_string_incl_seconds
 
@@ -450,10 +450,10 @@ class TestBid:
                 ("creation_time", "rate [ct./kWh]", "energy [kWh]", "price [ct.]", "buyer"))
 
 
-class TestTradeOrderInfo:
+class TestTradeOrdersInfo:
     @staticmethod
     def test_to_json_string():
-        trade_orders_info = TradeOrderInfo(
+        trade_orders_info = TradeOrdersInfo(
             1, 1, 1, 1, 1
         )
         assert (trade_orders_info.to_json_string() ==
@@ -461,11 +461,11 @@ class TestTradeOrderInfo:
 
     @staticmethod
     def test_from_json():
-        trade_orders_info = TradeOrderInfo(
+        trade_orders_info = TradeOrdersInfo(
             1, 1, 1, 1, 1
         )
         trade_orders_info_json = trade_orders_info.to_json_string()
-        assert (TradeOrderInfo.from_json(trade_orders_info_json) ==
+        assert (TradeOrdersInfo.from_json(trade_orders_info_json) ==
                 trade_orders_info)
 
 
@@ -512,7 +512,7 @@ class TestTrade:
         assert json.loads(trade.to_json_string()).get("residual") is not None
 
         # Test the trade_orders_info check
-        trade.trade_orders_info = TradeOrderInfo(1, 2, 3, 4, 5)
+        trade.trade_orders_info = TradeOrdersInfo(1, 2, 3, 4, 5)
         trade_dict["trade_orders_info"] = (
             deepcopy(trade.trade_orders_info).to_json_string())
         assert (trade.to_json_string() ==
@@ -524,7 +524,7 @@ class TestTrade:
             **self.initial_data
         )
         trade.residual = deepcopy(trade.order)
-        trade.trade_orders_info = TradeOrderInfo(
+        trade.trade_orders_info = TradeOrdersInfo(
             1, 1, 1, 1, 1
         )
         assert Trade.from_json(trade.to_json_string()) == trade

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -50,8 +50,8 @@ class TestOrdersMatch:
 
     @staticmethod
     def test_serializable_dict():
-        """Test the serializable_dict method of BidOfferMatch dataclass."""
-        bid_offer_match = OrdersMatch(
+        """Test the serializable_dict method of OrderMatch dataclass."""
+        orders_match = OrdersMatch(
             market_id="market_id",
             time_slot="2021-10-06T12:00",
             bids=[{"type": "bid"}],
@@ -64,53 +64,53 @@ class TestOrdersMatch:
                          "offers": [{"type": "offer"}],
                          "selected_energy": 1,
                          "trade_rate": 1}
-        assert bid_offer_match.serializable_dict() == expected_dict
+        assert orders_match.serializable_dict() == expected_dict
 
     @staticmethod
     def test_is_valid_dict():
-        """Test the is_valid_dict method of BidOfferMatch dataclass."""
-        bid_offer_match = {"market_id": "market_id",
-                           "time_slot": "2021-10-06T12:00",
-                           "bids": [{"type": "bid"}],
-                           "offers": [{"type": "offer"}],
-                           "selected_energy": 1,
-                           "trade_rate": 1}
-        assert OrdersMatch.is_valid_dict(bid_offer_match)
+        """Test the is_valid_dict method of OrderMatch dataclass."""
+        orders_match = {"market_id": "market_id",
+                        "time_slot": "2021-10-06T12:00",
+                        "bids": [{"type": "bid"}],
+                        "offers": [{"type": "offer"}],
+                        "selected_energy": 1,
+                        "trade_rate": 1}
+        assert OrdersMatch.is_valid_dict(orders_match)
 
         # Key does not exist
-        bid_offer_match = {"market_id": "market_id",
-                           "time_slot": "2021-10-06T12:00",
-                           "bids": [{"type": "bid"}],
-                           "offers": [{"type": "offer"}],
-                           "selected_energy": 1,
-                           }
-        assert not OrdersMatch.is_valid_dict(bid_offer_match)
+        orders_match = {"market_id": "market_id",
+                        "time_slot": "2021-10-06T12:00",
+                        "bids": [{"type": "bid"}],
+                        "offers": [{"type": "offer"}],
+                        "selected_energy": 1,
+                        }
+        assert not OrdersMatch.is_valid_dict(orders_match)
 
         # Wrong type
-        bid_offer_match = {"market_id": "market_id",
-                           "time_slot": "2021-10-06T12:00",
-                           "bids": [{"type": "bid"}],
-                           "offers": [{"type": "offer"}],
-                           "selected_energy": 1,
-                           "trade_rate": ""}
-        assert not OrdersMatch.is_valid_dict(bid_offer_match)
+        orders_match = {"market_id": "market_id",
+                        "time_slot": "2021-10-06T12:00",
+                        "bids": [{"type": "bid"}],
+                        "offers": [{"type": "offer"}],
+                        "selected_energy": 1,
+                        "trade_rate": ""}
+        assert not OrdersMatch.is_valid_dict(orders_match)
 
     @staticmethod
     def test_from_dict():
-        """Test the from_dict method of BidOfferMatch dataclass."""
+        """Test the from_dict method of OrderMatch dataclass."""
         expected_dict = {"market_id": "market_id",
                          "time_slot": "2021-10-06T12:00",
                          "bids": [{"type": "bid"}],
                          "offers": [{"type": "offer"}],
                          "selected_energy": 1,
                          "trade_rate": 1}
-        bid_offer_match = OrdersMatch.from_dict(expected_dict)
-        assert bid_offer_match.market_id == expected_dict["market_id"]
-        assert bid_offer_match.time_slot == expected_dict["time_slot"]
-        assert bid_offer_match.bids == expected_dict["bids"]
-        assert bid_offer_match.offers == expected_dict["offers"]
-        assert bid_offer_match.selected_energy == expected_dict["selected_energy"]
-        assert bid_offer_match.trade_rate == expected_dict["trade_rate"]
+        orders_match = OrdersMatch.from_dict(expected_dict)
+        assert orders_match.market_id == expected_dict["market_id"]
+        assert orders_match.time_slot == expected_dict["time_slot"]
+        assert orders_match.bids == expected_dict["bids"]
+        assert orders_match.offers == expected_dict["offers"]
+        assert orders_match.selected_energy == expected_dict["selected_energy"]
+        assert orders_match.trade_rate == expected_dict["trade_rate"]
 
 
 class TestBaseOrder:
@@ -130,66 +130,66 @@ class TestBaseOrder:
 
     def test_init(self):
         """Test __init__."""
-        bid_offer = BaseOrder(
+        orders = BaseOrder(
             **self.initial_data
         )
-        assert bid_offer.id == str(self.initial_data["id"])
-        assert bid_offer.creation_time == self.initial_data["creation_time"]
-        assert bid_offer.price == self.initial_data["price"]
-        assert bid_offer.energy == self.initial_data["energy"]
-        assert bid_offer.original_price == self.initial_data["original_price"]
-        assert bid_offer.energy_rate == self.initial_data["price"] / self.initial_data["energy"]
-        assert bid_offer.attributes == self.initial_data["attributes"]
-        assert bid_offer.requirements == self.initial_data["requirements"]
+        assert orders.id == str(self.initial_data["id"])
+        assert orders.creation_time == self.initial_data["creation_time"]
+        assert orders.price == self.initial_data["price"]
+        assert orders.energy == self.initial_data["energy"]
+        assert orders.original_price == self.initial_data["original_price"]
+        assert orders.energy_rate == self.initial_data["price"] / self.initial_data["energy"]
+        assert orders.attributes == self.initial_data["attributes"]
+        assert orders.requirements == self.initial_data["requirements"]
 
         # Test whether the original_price will resort to the "price" member
         self.initial_data.pop("original_price")
-        bid_offer = BaseOrder(
+        orders = BaseOrder(
             **self.initial_data
         )
-        assert bid_offer.original_price == self.initial_data["price"]
+        assert orders.original_price == self.initial_data["price"]
 
     def test_update_price(self):
-        bid_offer = BaseOrder(
+        orders = BaseOrder(
             **self.initial_data
         )
-        bid_offer.update_price(30)
-        assert bid_offer.price == 30
-        assert bid_offer.energy_rate == 30 / bid_offer.energy
+        orders.update_price(30)
+        assert orders.price == 30
+        assert orders.energy_rate == 30 / orders.energy
 
     def test_update_energy(self):
-        bid_offer = BaseOrder(
+        orders = BaseOrder(
             **self.initial_data
         )
-        bid_offer.update_energy(40)
-        assert bid_offer.energy == 40
-        assert bid_offer.energy_rate == bid_offer.price / 40
+        orders.update_energy(40)
+        assert orders.energy == 40
+        assert orders.energy_rate == orders.price / 40
 
     def test_to_json_string(self):
-        bid_offer = BaseOrder(
+        orders = BaseOrder(
             **self.initial_data
         )
-        obj_dict = deepcopy(bid_offer.__dict__)
+        obj_dict = deepcopy(orders.__dict__)
 
         obj_dict["type"] = "BaseOrder"
-        assert bid_offer.to_json_string() == json.dumps(obj_dict, default=json_datetime_serializer)
+        assert orders.to_json_string() == json.dumps(obj_dict, default=json_datetime_serializer)
         assert json.loads(
-            bid_offer.to_json_string(my_extra_key=10)).get("my_extra_key") == 10
+            orders.to_json_string(my_extra_key=10)).get("my_extra_key") == 10
 
     def test_serializable_dict(self):
-        bid_offer = BaseOrder(
+        orders = BaseOrder(
             **self.initial_data
         )
-        assert bid_offer.serializable_dict() == {
+        assert orders.serializable_dict() == {
             "type": "BaseOrder",
-            "id": str(bid_offer.id),
-            "energy": bid_offer.energy,
-            "energy_rate": bid_offer.energy_rate,
-            "original_price": bid_offer.original_price,
-            "creation_time": datetime_to_string_incl_seconds(bid_offer.creation_time),
-            "attributes": bid_offer.attributes,
-            "requirements": bid_offer.requirements,
-            "time_slot": datetime_to_string_incl_seconds(bid_offer.time_slot)
+            "id": str(orders.id),
+            "energy": orders.energy,
+            "energy_rate": orders.energy_rate,
+            "original_price": orders.original_price,
+            "creation_time": datetime_to_string_incl_seconds(orders.creation_time),
+            "attributes": orders.attributes,
+            "requirements": orders.requirements,
+            "time_slot": datetime_to_string_incl_seconds(orders.time_slot)
         }
 
     def test_from_json(self):
@@ -453,20 +453,20 @@ class TestBid:
 class TestTradeOrderInfo:
     @staticmethod
     def test_to_json_string():
-        trade_bid_offer_info = TradeOrderInfo(
+        trade_orders_info = TradeOrderInfo(
             1, 1, 1, 1, 1
         )
-        assert (trade_bid_offer_info.to_json_string() ==
-                json.dumps(asdict(trade_bid_offer_info), default=json_datetime_serializer))
+        assert (trade_orders_info.to_json_string() ==
+                json.dumps(asdict(trade_orders_info), default=json_datetime_serializer))
 
     @staticmethod
     def test_from_json():
-        trade_bid_offer_info = TradeOrderInfo(
+        trade_orders_info = TradeOrderInfo(
             1, 1, 1, 1, 1
         )
-        trade_bid_offer_info_json = trade_bid_offer_info.to_json_string()
-        assert (TradeOrderInfo.from_json(trade_bid_offer_info_json) ==
-                trade_bid_offer_info)
+        trade_orders_info_json = trade_orders_info.to_json_string()
+        assert (TradeOrderInfo.from_json(trade_orders_info_json) ==
+                trade_orders_info)
 
 
 class TestTrade:
@@ -474,7 +474,7 @@ class TestTrade:
         self.initial_data = {
             "id": "my_id",
             "creation_time": DEFAULT_DATETIME,
-            "offer_bid": Offer("id", DEFAULT_DATETIME, 1, 2, "seller"),
+            "order": Offer("id", DEFAULT_DATETIME, 1, 2, "seller"),
             "seller": "seller",
             "buyer": "buyer"}
 
@@ -482,9 +482,9 @@ class TestTrade:
         trade = Trade(**self.initial_data)
         assert (str(trade) ==
                 f"{{{trade.id!s:.6s}}} [origin: {trade.seller_origin} -> {trade.buyer_origin}] "
-                f"[{trade.seller} -> {trade.buyer}] {trade.offer_bid.energy} kWh"
-                f" @ {trade.offer_bid.price} {round(trade.offer_bid.energy_rate, 8)} "
-                f"{trade.offer_bid.id} [fee: {trade.fee_price} cts.]")
+                f"[{trade.seller} -> {trade.buyer}] {trade.order.energy} kWh"
+                f" @ {trade.order.price} {round(trade.order.energy_rate, 8)} "
+                f"{trade.order.id} [fee: {trade.fee_price} cts.]")
 
     @staticmethod
     def test_csv_fields():
@@ -493,38 +493,38 @@ class TestTrade:
 
     def test_csv_values(self):
         trade = Trade(**self.initial_data)
-        rate = round(trade.offer_bid.energy_rate, 4)
+        rate = round(trade.order.energy_rate, 4)
         assert (trade.csv_values() ==
-                (trade.creation_time, rate, trade.offer_bid.energy, trade.seller, trade.buyer))
+                (trade.creation_time, rate, trade.order.energy, trade.seller, trade.buyer))
 
     def test_to_json_string(self):
         trade = Trade(**self.initial_data)
         trade_dict = deepcopy(trade.__dict__)
-        trade_dict["offer_bid"] = trade_dict["offer_bid"].to_json_string()
+        trade_dict["order"] = trade_dict["order"].to_json_string()
         assert (trade.to_json_string() ==
                 json.dumps(trade_dict, default=json_datetime_serializer))
 
         # Test the residual check
-        trade.residual = deepcopy(trade.offer_bid)
-        trade_dict["residual"] = deepcopy(trade.offer_bid).to_json_string()
+        trade.residual = deepcopy(trade.order)
+        trade_dict["residual"] = deepcopy(trade.order).to_json_string()
         assert (trade.to_json_string() ==
                 json.dumps(trade_dict, default=json_datetime_serializer))
         assert json.loads(trade.to_json_string()).get("residual") is not None
 
-        # Test the offer_bid_trade_info check
-        trade.offer_bid_trade_info = TradeOrderInfo(1, 2, 3, 4, 5)
-        trade_dict["offer_bid_trade_info"] = (
-            deepcopy(trade.offer_bid_trade_info).to_json_string())
+        # Test the trade_orders_info check
+        trade.trade_orders_info = TradeOrderInfo(1, 2, 3, 4, 5)
+        trade_dict["trade_orders_info"] = (
+            deepcopy(trade.trade_orders_info).to_json_string())
         assert (trade.to_json_string() ==
                 json.dumps(trade_dict, default=json_datetime_serializer))
-        assert json.loads(trade.to_json_string()).get("offer_bid_trade_info") is not None
+        assert json.loads(trade.to_json_string()).get("trade_orders_info") is not None
 
     def test_from_json(self):
         trade = Trade(
             **self.initial_data
         )
-        trade.residual = deepcopy(trade.offer_bid)
-        trade.offer_bid_trade_info = TradeOrderInfo(
+        trade.residual = deepcopy(trade.order)
+        trade.trade_orders_info = TradeOrderInfo(
             1, 1, 1, 1, 1
         )
         assert Trade.from_json(trade.to_json_string()) == trade
@@ -545,7 +545,7 @@ class TestTrade:
         )
         assert trade.is_bid_trade is False
 
-        trade.offer_bid = Bid("id", DateTime.now(), 1, 2, "buyer")
+        trade.order = Bid("id", DateTime.now(), 1, 2, "buyer")
         assert trade.is_bid_trade is True
 
     def test_is_offer_trade(self):
@@ -554,7 +554,7 @@ class TestTrade:
         )
         assert trade.is_offer_trade is True
 
-        trade.offer_bid = Bid("id", DateTime.now(), 1, 2, "buyer")
+        trade.order = Bid("id", DateTime.now(), 1, 2, "buyer")
         assert trade.is_offer_trade is False
 
     @staticmethod
@@ -562,7 +562,7 @@ class TestTrade:
         trade = Trade(
             **{
                 "id": "my_id",
-                "offer_bid": Offer("id", DEFAULT_DATETIME, 1, 2, "seller"),
+                "order": Offer("id", DEFAULT_DATETIME, 1, 2, "seller"),
                 "buyer": "buyer",
                 "buyer_origin": "buyer_origin",
                 "seller_origin": "seller_origin",
@@ -580,11 +580,11 @@ class TestTrade:
             "type": "Trade",
             "match_type": "Offer",
             "id": trade.id,
-            "offer_bid_id": trade.offer_bid.id,
+            "order_id": trade.order.id,
             "residual_id": trade.residual.id if trade.residual is not None else None,
-            "energy": trade.offer_bid.energy,
-            "energy_rate": trade.offer_bid.energy_rate,
-            "price": trade.offer_bid.price,
+            "energy": trade.order.energy,
+            "energy_rate": trade.order.energy_rate,
+            "price": trade.order.price,
             "buyer": trade.buyer,
             "buyer_origin": trade.buyer_origin,
             "seller_origin": trade.seller_origin,
@@ -633,8 +633,8 @@ class TestBalancingTrade(TestTrade):
         trade = BalancingTrade(**self.initial_data)
         assert (str(trade) ==
                 f"{{{trade.id!s:.6s}}} [{trade.seller} -> {trade.buyer}] "
-                f"{trade.offer_bid.energy} kWh @ {trade.offer_bid.price}"
-                f" {trade.offer_bid.energy_rate} {trade.offer_bid.id}")
+                f"{trade.order.energy} kWh @ {trade.order.price}"
+                f" {trade.order.energy_rate} {trade.order.id}")
 
 
 class TestClearing:

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -28,7 +28,7 @@ import pytest
 from pendulum import DateTime, datetime
 
 from gsy_framework.data_classes import (
-    OrdersMatch, BaseBidOffer, Offer, Bid, json_datetime_serializer,
+    OrdersMatch, BaseOrder, Offer, Bid, json_datetime_serializer,
     TradeBidOfferInfo, Trade, BalancingOffer, BalancingTrade, Clearing,
     MarketClearingState)
 from gsy_framework.utils import datetime_to_string_incl_seconds
@@ -45,8 +45,8 @@ def test_json_datetime_serializer():
     assert json_datetime_serializer(my_date_time) == datetime_to_string_incl_seconds(my_date_time)
 
 
-class TestBidOfferMatch:
-    """Tester class for the BidOfferMatch dataclass."""
+class TestOrdersMatch:
+    """Tester class for the OrdersMatch dataclass."""
 
     @staticmethod
     def test_serializable_dict():
@@ -113,8 +113,8 @@ class TestBidOfferMatch:
         assert bid_offer_match.trade_rate == expected_dict["trade_rate"]
 
 
-class TestBaseBidOffer:
-    """Test BaseBidOffer class."""
+class TestBaseOrder:
+    """Test BaseOrder class."""
 
     def setup_method(self):
         self.initial_data = {
@@ -130,7 +130,7 @@ class TestBaseBidOffer:
 
     def test_init(self):
         """Test __init__."""
-        bid_offer = BaseBidOffer(
+        bid_offer = BaseOrder(
             **self.initial_data
         )
         assert bid_offer.id == str(self.initial_data["id"])
@@ -144,13 +144,13 @@ class TestBaseBidOffer:
 
         # Test whether the original_price will resort to the "price" member
         self.initial_data.pop("original_price")
-        bid_offer = BaseBidOffer(
+        bid_offer = BaseOrder(
             **self.initial_data
         )
         assert bid_offer.original_price == self.initial_data["price"]
 
     def test_update_price(self):
-        bid_offer = BaseBidOffer(
+        bid_offer = BaseOrder(
             **self.initial_data
         )
         bid_offer.update_price(30)
@@ -158,7 +158,7 @@ class TestBaseBidOffer:
         assert bid_offer.energy_rate == 30 / bid_offer.energy
 
     def test_update_energy(self):
-        bid_offer = BaseBidOffer(
+        bid_offer = BaseOrder(
             **self.initial_data
         )
         bid_offer.update_energy(40)
@@ -166,22 +166,22 @@ class TestBaseBidOffer:
         assert bid_offer.energy_rate == bid_offer.price / 40
 
     def test_to_json_string(self):
-        bid_offer = BaseBidOffer(
+        bid_offer = BaseOrder(
             **self.initial_data
         )
         obj_dict = deepcopy(bid_offer.__dict__)
 
-        obj_dict["type"] = "BaseBidOffer"
+        obj_dict["type"] = "BaseOrder"
         assert bid_offer.to_json_string() == json.dumps(obj_dict, default=json_datetime_serializer)
         assert json.loads(
             bid_offer.to_json_string(my_extra_key=10)).get("my_extra_key") == 10
 
     def test_serializable_dict(self):
-        bid_offer = BaseBidOffer(
+        bid_offer = BaseOrder(
             **self.initial_data
         )
         assert bid_offer.serializable_dict() == {
-            "type": "BaseBidOffer",
+            "type": "BaseOrder",
             "id": str(bid_offer.id),
             "energy": bid_offer.energy,
             "energy_rate": bid_offer.energy_rate,
@@ -198,14 +198,14 @@ class TestBaseBidOffer:
             seller="seller"
         )
         offer_json = offer.to_json_string()
-        assert offer == BaseBidOffer.from_json(offer_json)
+        assert offer == BaseOrder.from_json(offer_json)
 
         bid = Bid(
             **self.initial_data,
             buyer="buyer"
         )
         bid_json = bid.to_json_string()
-        assert bid == BaseBidOffer.from_json(bid_json)
+        assert bid == BaseOrder.from_json(bid_json)
 
     @pytest.mark.parametrize("time_stamp", [None, DEFAULT_DATETIME])
     def test_from_json_deals_with_time_stamps_correctly(self, time_stamp):

--- a/tests/test_matching_algorithms/test_pay_as_clear_matching_algorithm.py
+++ b/tests/test_matching_algorithms/test_pay_as_clear_matching_algorithm.py
@@ -36,7 +36,7 @@ class TestPayAsClearMatchingAlgorithm:
     def validate_matching(
             matching: Dict, matched_energy: float,
             offer_id: str, bid_id: str) -> None:
-        """Validate if a BidOfferMatch dict is valid.
+        """Validate if a OrdersMatch dict is valid.
 
         Raises:
             AssertionError

--- a/tests/test_matching_algorithms/test_pay_as_clear_matching_algorithm.py
+++ b/tests/test_matching_algorithms/test_pay_as_clear_matching_algorithm.py
@@ -36,7 +36,7 @@ class TestPayAsClearMatchingAlgorithm:
     def validate_matching(
             matching: Dict, matched_energy: float,
             offer_id: str, bid_id: str) -> None:
-        """Validate if a OrdersMatch dict is valid.
+        """Validate if OrdersMatch dict is valid.
 
         Raises:
             AssertionError

--- a/tests/test_matching_algorithms/test_pay_as_clear_matching_algorithm.py
+++ b/tests/test_matching_algorithms/test_pay_as_clear_matching_algorithm.py
@@ -54,7 +54,7 @@ class TestPayAsClearMatchingAlgorithm:
             ([12, 123, 432, 543, 1], 1111.2),
             ([867867.61, 123.98, 432.43, 12.12, 0.001], 868440)
         ])
-    def test_create_bid_offer_matches_respects_offer_bid_order(
+    def test_create_orders_matches_respects_orders_order(
             self, energy_values: List[float], clearing_energy: float) -> None:
         bids_list = []
         offers_list = []
@@ -68,7 +68,7 @@ class TestPayAsClearMatchingAlgorithm:
         current_time = str(pendulum.now())
         time_slot = "2021-10-06T12:00"
         pac_algo.state.clearing[market_id] = {current_time: Clearing(1, clearing_energy)}
-        matches = pac_algo._create_bid_offer_matches(
+        matches = pac_algo._create_orders_matches(
             offers_list, bids_list, market_id=market_id, time_slot=time_slot,
             current_time=current_time)
         assert len(matches) == 5
@@ -76,7 +76,7 @@ class TestPayAsClearMatchingAlgorithm:
             self.validate_matching(
                 matches[index], energy_values[index], f"offer_id{index}", f"bid_id{index}")
 
-    def test_create_bid_offer_matches_can_handle_partial_bids(self):
+    def test_create_orders_matches_can_handle_partial_bids(self):
         bids_list = [
             Bid("bid_id1", pendulum.now(), 9, 9, "Buyer")._asdict(),
             Bid("bid_id2", pendulum.now(), 3, 3, "Buyer")._asdict(),
@@ -92,7 +92,7 @@ class TestPayAsClearMatchingAlgorithm:
         current_time = str(pendulum.now())
         time_slot = "2021-10-06T12:00"
         pac_algo.state.clearing[market_id] = {current_time: Clearing(1, 15)}
-        matches = pac_algo._create_bid_offer_matches(
+        matches = pac_algo._create_orders_matches(
             offers_list, bids_list, market_id=market_id, time_slot=time_slot,
             current_time=current_time)
 
@@ -105,7 +105,7 @@ class TestPayAsClearMatchingAlgorithm:
         self.validate_matching(matches[5], 2, "offer_id5", "bid_id2")
         self.validate_matching(matches[6], 3, "offer_id5", "bid_id3")
 
-    def test_create_bid_offer_matches_can_handle_partial_offers(self):
+    def test_create_orders_matches_can_handle_partial_offers(self):
         bid_list = []
         for index in range(1, 6):
             bid_list.append(
@@ -122,7 +122,7 @@ class TestPayAsClearMatchingAlgorithm:
         time_slot = "2021-10-06T12:00"
         current_time = str(pendulum.now())
         pac_algo.state.clearing[market_id] = {current_time: Clearing(1, 15)}
-        matches = pac_algo._create_bid_offer_matches(
+        matches = pac_algo._create_orders_matches(
             offer_list, bid_list, market_id=market_id, time_slot=time_slot,
             current_time=current_time)
 
@@ -134,7 +134,7 @@ class TestPayAsClearMatchingAlgorithm:
         self.validate_matching(matches[5], 2, "offer_id2", "bid_id5")
         self.validate_matching(matches[6], 3, "offer_id3", "bid_id5")
 
-    def test_create_bid_offer_matches_can_handle_excessive_offer_energy(self):
+    def test_create_orders_matches_can_handle_excessive_offer_energy(self):
         bid_list = []
         for index in range(1, 6):
             bid_list.append(
@@ -151,7 +151,7 @@ class TestPayAsClearMatchingAlgorithm:
         time_slot = "2021-10-06T12:00"
         current_time = str(pendulum.now())
         pac_algo.state.clearing[market_id] = {current_time: Clearing(1, 15)}
-        matches = pac_algo._create_bid_offer_matches(
+        matches = pac_algo._create_orders_matches(
             offer_list, bid_list, market_id=market_id, time_slot=time_slot,
             current_time=current_time)
 
@@ -164,7 +164,7 @@ class TestPayAsClearMatchingAlgorithm:
         self.validate_matching(matches[5], 2, "offer_id2", "bid_id5")
         self.validate_matching(matches[6], 3, "offer_id3", "bid_id5")
 
-    def test_create_bid_offer_matches_can_handle_excessive_bid_energy(self):
+    def test_create_orders_matches_can_handle_excessive_bid_energy(self):
         bid_list = []
         for index in range(1, 6):
             bid_list.append(
@@ -181,7 +181,7 @@ class TestPayAsClearMatchingAlgorithm:
         time_slot = "2021-10-06T12:00"
         current_time = str(pendulum.now())
         pac_algo.state.clearing[market_id] = {current_time: Clearing(1, 15)}
-        matches = pac_algo._create_bid_offer_matches(
+        matches = pac_algo._create_orders_matches(
             offer_list, bid_list, market_id=market_id, time_slot=time_slot,
             current_time=current_time)
 
@@ -194,7 +194,7 @@ class TestPayAsClearMatchingAlgorithm:
         self.validate_matching(matches[5], 2, "offer_id2", "bid_id5")
         self.validate_matching(matches[6], 3, "offer_id3", "bid_id5")
 
-    def test_create_bid_offer_matches_can_match_with_only_one_offer(self):
+    def test_create_orders_matches_can_match_with_only_one_offer(self):
         bid_list = []
         for index in range(1, 6):
             bid_list.append(
@@ -209,7 +209,7 @@ class TestPayAsClearMatchingAlgorithm:
         current_time = str(pendulum.now())
         time_slot = "2021-10-06T12:00"
         pac_algo.state.clearing[market_id] = {current_time: Clearing(1, 15)}
-        matches = pac_algo._create_bid_offer_matches(
+        matches = pac_algo._create_orders_matches(
             offer_list, bid_list, market_id=market_id, time_slot=time_slot,
             current_time=current_time)
 
@@ -220,7 +220,7 @@ class TestPayAsClearMatchingAlgorithm:
         self.validate_matching(matches[3], 4, "offer_id1", "bid_id4")
         self.validate_matching(matches[4], 5, "offer_id1", "bid_id5")
 
-    def test_create_bid_offer_matches_can_match_with_only_one_bid(self):
+    def test_create_orders_matches_can_match_with_only_one_bid(self):
         bids_list = [
             Bid("bid_id1", pendulum.now(), 9, 90123456789, "B")._asdict()
         ]
@@ -235,7 +235,7 @@ class TestPayAsClearMatchingAlgorithm:
         current_time = str(pendulum.now())
         time_slot = "2021-10-06T12:00"
         pac_algo.state.clearing[market_id] = {current_time: Clearing(1, 15)}
-        matches = pac_algo._create_bid_offer_matches(
+        matches = pac_algo._create_orders_matches(
             offers_list, bids_list, market_id=market_id, time_slot=time_slot,
             current_time=current_time)
 

--- a/tests/test_settings_validators.py
+++ b/tests/test_settings_validators.py
@@ -81,19 +81,19 @@ class TestValidateGlobalSettings:
         validate_global_settings(
             {"spot_market_type": ConstSettings.IAASettings.MARKET_TYPE_LIMIT.max})
 
-    def test_wrong_bid_offer_match_algo(self):
-        """Validate that bid_offer_match_algo should be within the range limit."""
+    def test_wrong_orders_match_algo(self):
+        """Validate that orders_match_algo should be within the range limit."""
         with pytest.raises(GSySettingsException):
             validate_global_settings(
-                {"bid_offer_match_algo":
-                 ConstSettings.IAASettings.BID_OFFER_MATCH_TYPE_LIMIT.min - 1})
+                {"orders_match_algo":
+                 ConstSettings.IAASettings.ORDERS_MATCH_TYPE_LIMIT.min - 1})
         with pytest.raises(GSySettingsException):
             validate_global_settings(
-                {"bid_offer_match_algo":
-                 ConstSettings.IAASettings.BID_OFFER_MATCH_TYPE_LIMIT.max + 1})
+                {"orders_match_algo":
+                 ConstSettings.IAASettings.ORDERS_MATCH_TYPE_LIMIT.max + 1})
         validate_global_settings(
-            {"bid_offer_match_algo":
-             ConstSettings.IAASettings.BID_OFFER_MATCH_TYPE_LIMIT.max})
+            {"orders_match_algo":
+             ConstSettings.IAASettings.ORDERS_MATCH_TYPE_LIMIT.max})
 
     def test_wrong_cloud_coverage(self):
         with pytest.raises(GSySettingsException):


### PR DESCRIPTION
Changes introduced in this PR:

1. Rename `BidOfferMatch` to `OrdersMatch`
2. Rename `BaseBidOffer` to `BaseOrder`
3. Rename `BidOfferMatchAlgoEnum` to `OrdersMatchAlgoEnum`
4. Rename `TradeBidOfferInfo` to `TradeOrdersInfo`
5. Rename the `offer_bid` member of `Trade` to `order` and updated the serializable dict key (could break backwards compatibility)
5. Rename `EXPORT_OFFER_BID_TRADE_HR` constant to `EXPORT_ORDERS_TRADE_HR`
6. Rename `BID_OFFER_MATCH_TYPE` constant to `ORDERS_MATCH_TYPE`
7. Rename `BID_OFFER_MATCH_TYPE_LIMIT` constant to `ORDERS_MATCH_TYPE_LIMIT`
8. Rename variables