### PR TITLE
Bug/gsye 61

### DIFF
--- a/gsy_framework/utils.py
+++ b/gsy_framework/utils.py
@@ -546,12 +546,13 @@ def convert_datetime_to_ui_str_format(data_time):
     return instance(data_time).format(DATE_TIME_UI_FORMAT)
 
 
-def is_time_slot_in_simulation_duration(time_slot: DateTime, config: "GlobalConfig" = None) -> bool:
+def is_time_slot_in_simulation_duration(
+        time_slot: DateTime, config: "GlobalConfig" = None) -> bool:
     """
     Check whether a specific timeslot is inside the range of the simulation duration.
     :param time_slot: Timeslot that is checked if it is in the simulation duration
-    :param config: Optional configuration settings object that is used for the start / end date parameters. In case it
-                   is not provided, GlobalConfig object is used isntead
+    :param config: Optional configuration settings object that is used for the start / end date
+                   parameters. In case it is not provided, GlobalConfig object is used instead
     :return: True if the timeslot is in the simulation duration, false otherwise
     """
     if config is None:

--- a/gsy_framework/utils.py
+++ b/gsy_framework/utils.py
@@ -80,7 +80,7 @@ def generate_market_slot_list_from_config(sim_duration: duration, start_timestam
         start_timestamp + (slot_length * i) for i in range(
             (sim_duration + slot_length) //
             slot_length - 1)
-        if (slot_length * i) <= sim_duration]
+        if is_time_slot_in_simulation_duration(start_timestamp + (slot_length * i))]
 
 
 def generate_market_slot_list(start_timestamp=None):
@@ -544,3 +544,20 @@ def sort_list_of_dicts_by_attribute(input_list: List[Dict], attribute: str, reve
 def convert_datetime_to_ui_str_format(data_time):
     """Convert a datetime object into the format required by the UI."""
     return instance(data_time).format(DATE_TIME_UI_FORMAT)
+
+
+def is_time_slot_in_simulation_duration(time_slot: DateTime, config: "GlobalConfig" = None) -> bool:
+    """
+    Check whether a specific timeslot is inside the range of the simulation duration.
+    :param time_slot: Timeslot that is checked if it is in the simulation duration
+    :param config: Optional configuration settings object that is used for the start / end date parameters. In case it
+                   is not provided, GlobalConfig object is used isntead
+    :return: True if the timeslot is in the simulation duration, false otherwise
+    """
+    if config is None:
+        start_date = GlobalConfig.start_date
+        end_date = GlobalConfig.start_date + GlobalConfig.sim_duration
+    else:
+        start_date = config.start_date
+        end_date = config.end_date
+    return start_date <= time_slot < end_date or GlobalConfig.IS_CANARY_NETWORK

--- a/gsy_framework/utils.py
+++ b/gsy_framework/utils.py
@@ -549,11 +549,14 @@ def convert_datetime_to_ui_str_format(data_time):
 def is_time_slot_in_simulation_duration(
         time_slot: DateTime, config: "GlobalConfig" = None) -> bool:
     """
-    Check whether a specific timeslot is inside the range of the simulation duration.
-    :param time_slot: Timeslot that is checked if it is in the simulation duration
-    :param config: Optional configuration settings object that is used for the start / end date
-                   parameters. In case it is not provided, GlobalConfig object is used instead
-    :return: True if the timeslot is in the simulation duration, false otherwise
+        Check whether a specific timeslot is inside the range of the simulation duration.
+
+    Args:
+        time_slot: Timeslot that is checked if it is in the simulation duration
+        config: Optional configuration settings object that is used for the start / end date
+                parameters. In case it is not provided, GlobalConfig object is used instead
+
+    Returns: True if the timeslot is in the simulation duration, false otherwise
     """
     if config is None:
         start_date = GlobalConfig.start_date

--- a/tests/test_user_profile.py
+++ b/tests/test_user_profile.py
@@ -15,6 +15,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
+# pylint: disable=missing-function-docstring
 import unittest
 
 from pendulum import datetime, duration, today
@@ -27,15 +28,17 @@ from gsy_framework.unit_test_utils import assert_dicts_identical
 
 
 class TestReadUserProfile(unittest.TestCase):
+    """Test reading the user profiles."""
 
-    def _validate_timedeltas_are_followed(self, profile):
+    @staticmethod
+    def _validate_timedeltas_are_followed(profile):
         timestamps_list = list(profile.keys())
         assert timestamps_list[0] == datetime(2021, 2, 12, 0, 0, 0)
         assert timestamps_list[-1] == datetime(2021, 2, 14, 23, 45, 0)
 
-        for index, t in enumerate(timestamps_list):
+        for index, timestamp in enumerate(timestamps_list):
             if index + 1 < len(timestamps_list):
-                assert timestamps_list[index + 1] - t == duration(minutes=15)
+                assert timestamps_list[index + 1] - timestamp == duration(minutes=15)
 
     def test_generate_slot_based_zero_values_dict_from_profile(self):
         profile_dict = {
@@ -56,7 +59,8 @@ class TestReadUserProfile(unittest.TestCase):
         assert all(v == 1234.0 for v in filled_profile.values())
         self._validate_timedeltas_are_followed(filled_profile)
 
-    def test_interpolate_profile_values_to_slot(self):
+    @staticmethod
+    def test_interpolate_profile_values_to_slot():
         profile_dict = {
             datetime(2021, 2, 12, 0, 0, 0): 150.0,
             datetime(2021, 2, 12, 0, 5, 0): 100.0,
@@ -77,7 +81,8 @@ class TestReadUserProfile(unittest.TestCase):
         assert interp_profile[1] == 0.5
         assert interp_profile[2] == 0.1
 
-    def test_read_profile_for_player(self):
+    @staticmethod
+    def test_read_profile_for_player():
         profile_dict = {
             datetime(2021, 2, 12, 0, 0, 0): 150.0,
             datetime(2021, 2, 12, 0, 5, 0): 100.0,
@@ -96,7 +101,8 @@ class TestReadUserProfile(unittest.TestCase):
             datetime(2021, 2, 12, 0, 30, 0): 0.1
         })
 
-    def test_read_arbitrary_profile_returns_profile_with_correct_time_expansion(self):
+    @staticmethod
+    def test_read_arbitrary_profile_returns_profile_with_correct_time_expansion():
         market_maker_rate = 30
         if GlobalConfig.IS_CANARY_NETWORK:
             GlobalConfig.sim_duration = duration(hours=3)
@@ -122,5 +128,4 @@ class TestReadUserProfile(unittest.TestCase):
             GlobalConfig.sim_duration = duration(hours=1)
             mmr = read_arbitrary_profile(InputProfileTypes.IDENTITY, market_maker_rate)
             time_diff = list(mmr.keys())[-1] - today(tz=TIME_ZONE)
-            assert time_diff.hours == 0
-            assert time_diff.days == 1
+            assert time_diff.minutes == 45

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,13 +18,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # pylint: disable=missing-function-docstring
 # pylint: disable=missing-class-docstring
 from unittest.mock import patch, MagicMock
-
 import pytest
-from pendulum import datetime, today
+from pendulum import datetime, today, duration
 
-from gsy_framework.utils import (HomeRepresentationUtils, convert_datetime_to_ui_str_format,
-                                 execute_function_util, scenario_representation_traversal,
-                                 sort_list_of_dicts_by_attribute, str_to_pendulum_datetime)
+from gsy_framework.constants_limits import GlobalConfig
+from gsy_framework.utils import (
+    HomeRepresentationUtils, convert_datetime_to_ui_str_format, execute_function_util,
+    scenario_representation_traversal, sort_list_of_dicts_by_attribute, str_to_pendulum_datetime,
+    is_time_slot_in_simulation_duration
+)
 
 
 @pytest.fixture(name="scenario_repr")
@@ -103,3 +105,17 @@ class TestUtils:
 
         logging_mock.exception.assert_called_once_with(
             "%s raised exception: %s.", "function_mock_name", raised_exception)
+
+    @staticmethod
+    def test_is_time_slot_in_simulation_duration():
+        time_slot = GlobalConfig.start_date + duration(minutes=10)
+        assert is_time_slot_in_simulation_duration(time_slot) is True
+
+        time_slot = GlobalConfig.start_date - duration(minutes=1)
+        assert is_time_slot_in_simulation_duration(time_slot) is False
+
+        time_slot = GlobalConfig.start_date + GlobalConfig.sim_duration - duration(minutes=1)
+        assert is_time_slot_in_simulation_duration(time_slot) is True
+
+        time_slot = GlobalConfig.start_date + GlobalConfig.sim_duration + duration(minutes=1)
+        assert is_time_slot_in_simulation_duration(time_slot) is False


### PR DESCRIPTION
Ported the is_time_slot_in_simulation_duration method to gsy-framework in order to be reused by the framework itself when generating market slots for the simulation duration. 