### PR TITLE
Add buyer/seller IDs to CSV fields

### DIFF
--- a/gsy_framework/data_classes.py
+++ b/gsy_framework/data_classes.py
@@ -184,12 +184,13 @@ class Offer(BaseBidOffer):
     def csv_values(self) -> Tuple:
         """Return values of class members that are needed for creation of CSV export."""
         rate = round(self.energy_rate, 4)
-        return self.creation_time, rate, self.energy, self.price, self.seller
+        return self.creation_time, rate, self.energy, self.price, self.seller, self.seller_id
 
     @classmethod
     def csv_fields(cls) -> Tuple:
         """Return labels for csv_values for CSV export."""
-        return "creation_time", "rate [ct./kWh]", "energy [kWh]", "price [ct.]", "seller"
+        return ("creation_time", "rate [ct./kWh]", "energy [kWh]",
+                "price [ct.]", "seller", "seller_id")
 
     @staticmethod
     def copy(offer: "Offer") -> "Offer":
@@ -266,12 +267,13 @@ class Bid(BaseBidOffer):
     def csv_values(self) -> Tuple:
         """Return values of class members that are needed for creation of CSV export."""
         rate = round(self.energy_rate, 4)
-        return self.creation_time, rate, self.energy, self.price, self.buyer
+        return self.creation_time, rate, self.energy, self.price, self.buyer, self.buyer_id
 
     @classmethod
     def csv_fields(cls) -> Tuple:
         """Return labels for csv_values for CSV export."""
-        return "creation_time", "rate [ct./kWh]", "energy [kWh]", "price [ct.]", "buyer"
+        return ("creation_time", "rate [ct./kWh]", "energy [kWh]",
+                "price [ct.]", "buyer", "buyer_id")
 
     def __eq__(self, other) -> bool:
         return (self.id == other.id and
@@ -341,12 +343,14 @@ class Trade:
     @classmethod
     def csv_fields(cls) -> Tuple:
         """Return labels for csv_values for CSV export."""
-        return "creation_time", "rate [ct./kWh]", "energy [kWh]", "seller", "buyer"
+        return ("creation_time", "rate [ct./kWh]", "energy [kWh]",
+                "seller", "buyer", "seller_id", "buyer_id")
 
     def csv_values(self) -> Tuple:
         """Return values of class members that are needed for creation of CSV export."""
         rate = round(self.offer_bid.energy_rate, 4)
-        return self.creation_time, rate, self.offer_bid.energy, self.seller, self.buyer
+        return (self.creation_time, rate, self.offer_bid.energy,
+                self.seller, self.buyer, self.seller_id, self.buyer_id)
 
     def to_json_string(self) -> str:
         """Return json string of the representation."""

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -332,12 +332,18 @@ class TestOffer:
         )
         rate = round(offer.energy_rate, 4)
         assert offer.csv_values() == (
-            offer.creation_time, rate, offer.energy, offer.price, offer.seller)
+            offer.creation_time, rate, offer.energy, offer.price, offer.seller, offer.seller_id)
 
     @staticmethod
     def test_csv_fields():
-        assert (Offer.csv_fields() ==
-                ("creation_time", "rate [ct./kWh]", "energy [kWh]", "price [ct.]", "seller"))
+        assert (
+            Offer.csv_fields() == (
+                "creation_time",
+                "rate [ct./kWh]",
+                "energy [kWh]",
+                "price [ct.]",
+                "seller",
+                "seller_id"))
 
     def test_copy(self):
         offer = Offer(
@@ -445,12 +451,19 @@ class TestBid:
             **self.initial_data
         )
         rate = round(bid.energy_rate, 4)
-        assert bid.csv_values() == (bid.creation_time, rate, bid.energy, bid.price, bid.buyer)
+        assert (bid.csv_values() ==
+                (bid.creation_time, rate, bid.energy, bid.price, bid.buyer, bid.buyer_id))
 
     @staticmethod
     def test_csv_fields():
-        assert (Bid.csv_fields() ==
-                ("creation_time", "rate [ct./kWh]", "energy [kWh]", "price [ct.]", "buyer"))
+        assert (
+            Bid.csv_fields() == (
+                "creation_time",
+                "rate [ct./kWh]",
+                "energy [kWh]",
+                "price [ct.]",
+                "buyer",
+                "buyer_id"))
 
 
 class TestTradeBidOfferInfo:
@@ -492,13 +505,26 @@ class TestTrade:
     @staticmethod
     def test_csv_fields():
         assert Trade.csv_fields() == (
-            "creation_time", "rate [ct./kWh]", "energy [kWh]", "seller", "buyer")
+            "creation_time",
+            "rate [ct./kWh]",
+            "energy [kWh]",
+            "seller",
+            "buyer",
+            "seller_id",
+            "buyer_id")
 
     def test_csv_values(self):
         trade = Trade(**self.initial_data)
         rate = round(trade.offer_bid.energy_rate, 4)
-        assert (trade.csv_values() ==
-                (trade.creation_time, rate, trade.offer_bid.energy, trade.seller, trade.buyer))
+        assert (
+            trade.csv_values() == (
+                trade.creation_time,
+                rate,
+                trade.offer_bid.energy,
+                trade.seller,
+                trade.buyer,
+                trade.seller_id,
+                trade.buyer_id))
 
     def test_to_json_string(self):
         trade = Trade(**self.initial_data)


### PR DESCRIPTION
Previously, the CSV exports used to only contain the names of the
trading parties. Including the unique IDs makes it easier to connect
CSV rows to the corresponding entities.