### PR TITLE
Adapted the merge_last_market_results_to_global to not recreate the m…

### DIFF
--- a/gsy_framework/sim_results/aggregate_results.py
+++ b/gsy_framework/sim_results/aggregate_results.py
@@ -17,8 +17,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 from datetime import timedelta, date  # NOQA
 from typing import Dict, List
-from gsy_framework.utils import generate_market_slot_list_from_config, \
-    convert_datetime_to_str_in_list
 from gsy_framework.sim_results.area_throughput_stats import AreaThroughputStats
 from gsy_framework.sim_results.energy_trade_profile import EnergyTradeProfile
 from gsy_framework.sim_results.market_price_energy_day import MarketPriceEnergyDay
@@ -41,15 +39,10 @@ REQUESTED_FIELDS_CLASS_MAP = {
 
 def merge_last_market_results_to_global(
         market_results: Dict, global_results: Dict,
-        sim_duration: timedelta, start_date: date, slot_length: timedelta,
-        requested_fields: List = None
+        slot_list_ui_format: List = None, requested_fields: List = None
 ):
     if requested_fields is None:
         requested_fields = REQUESTED_FIELDS_LIST
-
-    slot_list_ui_format = convert_datetime_to_str_in_list(
-        generate_market_slot_list_from_config(sim_duration, start_date, slot_length),
-        ui_format=True)
 
     for field in requested_fields:
         global_results[field] = REQUESTED_FIELDS_CLASS_MAP[field].merge_results_to_global(

--- a/gsy_framework/utils.py
+++ b/gsy_framework/utils.py
@@ -68,19 +68,26 @@ def convert_datetime_to_str_in_list(in_list: List, ui_format: bool = False):
 
 
 def generate_market_slot_list_from_config(sim_duration: duration, start_timestamp: DateTime,
-                                          slot_length: duration):
+                                          slot_length: duration, ignore_duration_check=False):
     """
-    Returns a list of all slot times in Datetime format
-    @param sim_duration: Total simulation duration
-    @param start_timestamp: Start datetime of the simulation
-    @param slot_length: Market slot length
-    @return: List with market slot datetimes
+    Returns a list of all slot times in Datetime format.
+
+    Args:
+        sim_duration: Total simulation duration
+        start_timestamp: Start datetime of the simulation
+        slot_length: Market slot length
+        ignore_duration_check: Ignores the check if each timestamp is in the simulation duration.
+                               Useful for calling the method from context where no config has been
+                               set
+
+    Returns: List with market slot datetimes
     """
     return [
         start_timestamp + (slot_length * i) for i in range(
             (sim_duration + slot_length) //
             slot_length - 1)
-        if is_time_slot_in_simulation_duration(start_timestamp + (slot_length * i))]
+        if (ignore_duration_check or
+            is_time_slot_in_simulation_duration(start_timestamp + (slot_length * i)))]
 
 
 def generate_market_slot_list(start_timestamp=None):


### PR DESCRIPTION
…arket slot datetime list on every call, but to receive it from teh caller code. Adapted generate_market_slot_list_from_config to ignore the duration check specifically from context where there is no GlobalCofig set.