### PR TITLE
Fix bumpversion replacement

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,4 +5,4 @@ tag = True
 
 [bumpversion:file:setup.py]
 search = VERSION = "{current_version}"
-
+replace = VERSION = "{new_version}"

--- a/setup.py
+++ b/setup.py
@@ -2,25 +2,25 @@ from setuptools import setup, find_packages
 
 
 try:
-    with open('requirements/base.txt') as req:
-        REQUIREMENTS = [r.partition('#')[0] for r in req if not r.startswith('-e')]
+    with open("requirements/base.txt", encoding="utf-8") as req:
+        REQUIREMENTS = [r.partition("#")[0] for r in req if not r.startswith("-e")]
 except OSError:
     # Shouldn't happen
     REQUIREMENTS = []
 
-with open("README.md", "r") as readme:
+with open("README.md", "r", encoding="utf-8") as readme:
     README = readme.read()
 
 # *IMPORTANT*: Don't manually change the version here. Use the 'bumpversion' utility.
-VERSION = '1.1.0'
+VERSION = "1.1.0"
 
 setup(
     name="gsy-framework",
     description="GSy Framework",
     long_description=README,
-    author='GridSingularity',
-    author_email='d3a@gridsingularity.com',
-    url='https://github.com/gridsingularity/gsy-framework',
+    author="GridSingularity",
+    author_email="d3a@gridsingularity.com",
+    url="https://github.com/gridsingularity/gsy-framework",
     version=VERSION,
     packages=find_packages(where=".", exclude=["tests"]),
     package_dir={"gsy_framework": "gsy_framework"},


### PR DESCRIPTION
Allow using bumpversion in this repository, without needing to manually add the tag.