### PR TITLE
GSYE-111: Add selected_requirement attribute to the orders

### DIFF
--- a/gsy_framework/data_classes.py
+++ b/gsy_framework/data_classes.py
@@ -45,7 +45,8 @@ class BaseBidOffer:
     """Base class defining shared functionality of Bid and Offer market structures."""
     def __init__(self, id: str, creation_time: DateTime, price: float, energy: float,
                  original_price: Optional[float] = None, time_slot: DateTime = None,
-                 attributes: Dict = None, requirements: List[Dict] = None):
+                 attributes: Dict = None, requirements: List[Dict] = None,
+                 selected_requirement: Optional[Dict] = None):
         self.id = str(id)
         self.creation_time = creation_time
         self.time_slot = time_slot  # market slot of creation
@@ -55,6 +56,7 @@ class BaseBidOffer:
         self.energy_rate = limit_float_precision(self.price / self.energy)
         self.attributes = attributes
         self.requirements = requirements
+        self.selected_requirement = selected_requirement
 
     def update_price(self, price: float) -> None:
         """Update price member."""
@@ -91,7 +93,8 @@ class BaseBidOffer:
             "creation_time": datetime_to_string_incl_seconds(self.creation_time),
             "time_slot": datetime_to_string_incl_seconds(self.time_slot),
             "attributes": self.attributes,
-            "requirements": self.requirements
+            "requirements": self.requirements,
+            "selected_requirement": self.selected_requirement
         }
 
     @classmethod
@@ -124,10 +127,12 @@ class Offer(BaseBidOffer):
                  seller_id: str = None,
                  attributes: Dict = None,
                  requirements: List[Dict] = None,
-                 time_slot: DateTime = None):
+                 time_slot: DateTime = None,
+                 selected_requirement: Optional[Dict] = None):
         super().__init__(id=id, creation_time=creation_time, price=price, energy=energy,
                          original_price=original_price,
-                         attributes=attributes, requirements=requirements, time_slot=time_slot)
+                         attributes=attributes, requirements=requirements, time_slot=time_slot,
+                         selected_requirement=selected_requirement)
         self.seller = seller
         self.seller_origin = seller_origin
         self.seller_origin_id = seller_origin_id
@@ -170,7 +175,8 @@ class Offer(BaseBidOffer):
             seller_origin_id=offer.get("seller_origin_id"),
             seller_id=offer.get("seller_id"),
             attributes=offer.get("attributes"),
-            requirements=offer.get("requirements"))
+            requirements=offer.get("requirements"),
+            selected_requirement=offer.get("selected_requirement"))
 
     def __eq__(self, other) -> bool:
         return (self.id == other.id and
@@ -197,7 +203,7 @@ class Offer(BaseBidOffer):
         return Offer(offer.id, offer.creation_time, offer.price, offer.energy, offer.seller,
                      offer.original_price, offer.seller_origin, offer.seller_origin_id,
                      offer.seller_id, attributes=offer.attributes, requirements=offer.requirements,
-                     time_slot=offer.time_slot)
+                     time_slot=offer.time_slot, selected_requirement=offer.selected_requirement)
 
 
 class Bid(BaseBidOffer):
@@ -210,11 +216,12 @@ class Bid(BaseBidOffer):
                  buyer_id: str = None,
                  attributes: Dict = None,
                  requirements: List[Dict] = None,
-                 time_slot: Optional[DateTime] = None
-                 ):
+                 time_slot: Optional[DateTime] = None,
+                 selected_requirement: Optional[Dict] = None):
         super().__init__(id=id, creation_time=creation_time, price=price, energy=energy,
                          original_price=original_price,
-                         attributes=attributes, requirements=requirements, time_slot=time_slot)
+                         attributes=attributes, requirements=requirements, time_slot=time_slot,
+                         selected_requirement=selected_requirement)
         self.buyer = buyer
         self.buyer_origin = buyer_origin
         self.buyer_origin_id = buyer_origin_id
@@ -260,8 +267,8 @@ class Bid(BaseBidOffer):
             buyer_id=bid.get("buyer_id"),
             attributes=bid.get("attributes"),
             requirements=bid.get("requirements"),
-            time_slot=str_to_pendulum_datetime(bid.get("time_slot"))
-        )
+            time_slot=str_to_pendulum_datetime(bid.get("time_slot"),),
+            selected_requirement=bid.get("selected_requirement"))
 
     def csv_values(self) -> Tuple:
         """Return values of class members that are needed for creation of CSV export."""

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -190,7 +190,8 @@ class TestBaseBidOffer:
             "creation_time": datetime_to_string_incl_seconds(bid_offer.creation_time),
             "attributes": bid_offer.attributes,
             "requirements": bid_offer.requirements,
-            "time_slot": datetime_to_string_incl_seconds(bid_offer.time_slot)
+            "time_slot": datetime_to_string_incl_seconds(bid_offer.time_slot),
+            "selected_requirement": bid_offer.selected_requirement
         }
 
     def test_from_json(self):
@@ -305,7 +306,8 @@ class TestOffer:
             "seller_origin": offer.seller_origin,
             "seller_origin_id": offer.seller_origin_id,
             "seller_id": offer.seller_id,
-            "time_slot": datetime_to_string_incl_seconds(offer.time_slot)
+            "time_slot": datetime_to_string_incl_seconds(offer.time_slot),
+            "selected_requirement": offer.selected_requirement
         }
 
     def test_from_dict(self):
@@ -419,7 +421,8 @@ class TestBid:
             "buyer_origin": bid.buyer_origin,
             "buyer_origin_id": bid.buyer_origin_id,
             "buyer_id": bid.buyer_id,
-            "time_slot": datetime_to_string_incl_seconds(bid.time_slot)
+            "time_slot": datetime_to_string_incl_seconds(bid.time_slot),
+            "selected_requirement": bid.selected_requirement
         }
 
     def test_from_dict(self):

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ exclude = .env/* , .tox/*
 basepython = python3.8
 commands =
     python -c "import fcntl; fcntl.fcntl(1, fcntl.F_SETFL, 0)"
-    pip-sync requirements/tests.txt
+    pip-sync requirements/tests.txt requirements/pandapower.txt
     pip install -e .
     flake8
     coverage run -p -m pytest tests

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ exclude = .env/* , .tox/*
 basepython = python3.8
 commands =
     python -c "import fcntl; fcntl.fcntl(1, fcntl.F_SETFL, 0)"
-    pip-sync requirements/tests.txt requirements/pandapower.txt
+    pip-sync requirements/tests.txt
     pip install -e .
     flake8
     coverage run -p -m pytest tests


### PR DESCRIPTION
Orders can have multiple requirements, and the trade should depend on the **selected** requirements (like `energy` or `price`) to take priority over the `energy` or `price` of the actual order.
For instance, let's suppose that we have an offer `offer("seller", energy=10, price=10, requirements=[{"preferred_partners": ["buyerA",] "price": 5]}])`, and a bid `bid("buyerA", energy=10, price=10}])`.
The requirement of the offer is satisfied when creating the match, so the price should be set to 5 instead of 10 because in the validation process of the recommendations we check these values (check [here](https://github.com/gridsingularity/gsy-e/blob/9e4cbeee3f202f50286dbc98039d47e4ce7c631f/src/gsy_e/models/market/two_sided.py#L373)).
In the validation function I posted, we're checking the `price` and `energy` members of the orders (which may be not used), so I saw that we have two possible patches for this:

1. Overwrite the order's members when creating the recommendation (I believe this is a not a good approach for a set of reasons I'm ready to list upon request)
2. pass the `selected_requirement`, it's the requirement that was picked when creating the recommendation so it should be checked before any other member (it's quite important to know which requirement was selected imo)

In this PR, I adopted the second solution, added an extra `selected_requirement`, [populated it when matching based on recommendations](https://github.com/gridsingularity/gsy-myco-sdk/pull/36) and used it in the [validation](https://github.com/gridsingularity/gsy-e/pull/1349) 
