### PR TITLE
Avoid KeyError when dealing with d3a_cost in savings KPI

### DIFF
--- a/gsy_framework/sim_results/kpi.py
+++ b/gsy_framework/sim_results/kpi.py
@@ -395,7 +395,8 @@ class KPI(ResultsBaseClass):
                 self.savings_state[area_dict["uuid"]].fit_revenue = (
                     last_known_state_data["fit_revenue"])
                 self.savings_state[area_dict["uuid"]].gsy_e_cost = (
-                    last_known_state_data["gsy_e_cost"] or last_known_state_data["d3a_cost"])
+                    last_known_state_data.get("gsy_e_cost")
+                    or last_known_state_data.get("d3a_cost"))
 
     # pylint: disable=(arguments-differ
     @staticmethod


### PR DESCRIPTION
We currently have two possible names for costs in the savings KPI: `d3a_cost` and `gsy_e_cost`. 
The `d3a_cost` key was replaced by `gsy_e_cost` and can therefore be missing. However, this check currently fails with a `KeyError` exception when the old `d3a_cost` key is not found.

This PR fixes the issue.