### PR TITLE
Avoid None values when retrieving savings costs

### DIFF
--- a/gsy_framework/sim_results/kpi.py
+++ b/gsy_framework/sim_results/kpi.py
@@ -395,8 +395,8 @@ class KPI(ResultsBaseClass):
                 self.savings_state[area_dict["uuid"]].fit_revenue = (
                     last_known_state_data["fit_revenue"])
                 self.savings_state[area_dict["uuid"]].gsy_e_cost = (
-                    last_known_state_data.get("gsy_e_cost")
-                    or last_known_state_data.get("d3a_cost"))
+                    last_known_state_data.get("gsy_e_cost", 0)
+                    or last_known_state_data.get("d3a_cost", 0))
 
     # pylint: disable=(arguments-differ
     @staticmethod

--- a/gsy_framework/sim_results/kpi.py
+++ b/gsy_framework/sim_results/kpi.py
@@ -389,11 +389,11 @@ class KPI(ResultsBaseClass):
             if not has_grand_children(area_dict):
                 self.savings_state[area_dict["uuid"]] = SavingsKPI()
                 self.savings_state[area_dict["uuid"]].base_case_cost = (
-                    last_known_state_data["base_case_cost"])
+                    last_known_state_data.get("base_case_cost", 0))
                 self.savings_state[area_dict["uuid"]].utility_bill = (
-                    last_known_state_data["utility_bill"])
+                    last_known_state_data.get("utility_bill", 0))
                 self.savings_state[area_dict["uuid"]].fit_revenue = (
-                    last_known_state_data["fit_revenue"])
+                    last_known_state_data.get("fit_revenue", 0))
                 self.savings_state[area_dict["uuid"]].gsy_e_cost = (
                     last_known_state_data.get("gsy_e_cost", 0)
                     or last_known_state_data.get("d3a_cost", 0))


### PR DESCRIPTION
The fix implemented in #320 brought to light another issue with the computation of the `saving_absolute` value. This PR is an attempt to fix it.