### PR TITLE
GSYE-108: Remove Storage loss per hour mechanism

### DIFF
--- a/gsy_framework/constants_limits.py
+++ b/gsy_framework/constants_limits.py
@@ -115,15 +115,6 @@ class ConstSettings:
         # Min allowed battery SOC, range is [0, 100] %.
         MIN_ALLOWED_SOC = 10
 
-        # Controls the energy loss of the storage over time#
-        # LOSS_FUNCTION = 1 ==> relative loss
-        # LOSS_FUNCTION = 2 ==> absolute loss
-        LOSS_FUNCTION = 1
-        LOSS_FUNCTION_LIMIT = RangeLimit(1, 2)
-        LOSS_PER_HOUR = 0
-        LOSS_PER_HOUR_ABSOLUTE_LIMIT = RangeLimit(0, 10000)
-        LOSS_PER_HOUR_RELATIVE_LIMIT = RangeLimit(0, 1)
-
     class LoadSettings:
         """Default settings for load assets."""
 

--- a/gsy_framework/validators/storage_validator.py
+++ b/gsy_framework/validators/storage_validator.py
@@ -27,10 +27,9 @@ class StorageValidator(BaseValidator):
 
     @classmethod
     def validate(cls, **kwargs):
-        """Validate energy and rate values and the loss function configuration of the device."""
+        """Validate energy and rate values of the device."""
         cls.validate_energy(**kwargs)
         cls.validate_rate(**kwargs)
-        cls._validate_loss_function(**kwargs)
 
     @classmethod
     def validate_energy(cls, **kwargs):
@@ -173,42 +172,3 @@ class StorageValidator(BaseValidator):
             fit_to_limit=kwargs.get("fit_to_limit"),
             energy_rate_increase_per_update=kwargs.get("energy_rate_increase_per_update"),
             energy_rate_decrease_per_update=kwargs.get("energy_rate_decrease_per_update"))
-
-    @staticmethod
-    def _validate_loss_function(**kwargs):
-        if kwargs.get("loss_function") is None:
-            return
-
-        error_message = {"misconfiguration": [
-            "loss_function should either be "
-            f"{StorageSettings.LOSS_FUNCTION_LIMIT.min} or "
-            f"{StorageSettings.LOSS_FUNCTION_LIMIT.max}."]}
-        utils.validate_range_limit(
-            StorageSettings.LOSS_FUNCTION_LIMIT.min, kwargs["loss_function"],
-            StorageSettings.LOSS_FUNCTION_LIMIT.max, error_message)
-
-        if kwargs.get("loss_per_hour") is None:
-            return
-
-        if kwargs["loss_function"] == 1:
-            error_message = {
-                "misconfiguration": [
-                    "loss_per_hour should be in between "
-                    f"{StorageSettings.LOSS_PER_HOUR_RELATIVE_LIMIT.min} & "
-                    f"{StorageSettings.LOSS_PER_HOUR_RELATIVE_LIMIT.max}."]}
-            utils.validate_range_limit(
-                StorageSettings.LOSS_PER_HOUR_RELATIVE_LIMIT.min,
-                kwargs["loss_per_hour"],
-                StorageSettings.LOSS_PER_HOUR_RELATIVE_LIMIT.max,
-                error_message)
-        else:
-            error_message = {
-                "misconfiguration": [
-                    "loss_per_hour should be in between "
-                    f"{StorageSettings.LOSS_PER_HOUR_ABSOLUTE_LIMIT.min} & "
-                    f"{StorageSettings.LOSS_PER_HOUR_ABSOLUTE_LIMIT.max}."]}
-            utils.validate_range_limit(
-                StorageSettings.LOSS_PER_HOUR_ABSOLUTE_LIMIT.min,
-                kwargs["loss_per_hour"],
-                StorageSettings.LOSS_PER_HOUR_ABSOLUTE_LIMIT.max,
-                error_message)

--- a/tests/test_device_validator.py
+++ b/tests/test_device_validator.py
@@ -133,9 +133,7 @@ class TestValidateDeviceSettings:
         {"fit_to_limit": False, "energy_rate_increase_per_update": 3,
          "energy_rate_decrease_per_update": 3},
         {"fit_to_limit": False, "energy_rate_decrease_per_update": 3,
-         "energy_rate_increase_per_update": 3},
-        {"loss_function": 1, "loss_per_hour": 1},
-        {"loss_function": 2, "loss_per_hour": 300},
+         "energy_rate_increase_per_update": 3}
     ])
     def test_storage_device_setting_succeeds(valid_arguments):
         """The storage device validation succeeds when correct arguments are provided."""
@@ -160,11 +158,7 @@ class TestValidateDeviceSettings:
         {"fit_to_limit": True, "energy_rate_increase_per_update": 3},
         {"fit_to_limit": True, "energy_rate_decrease_per_update": 3},
         {"fit_to_limit": False, "energy_rate_increase_per_update": 3},
-        {"fit_to_limit": False, "energy_rate_decrease_per_update": 3},
-        {"loss_function": 1, "loss_per_hour": 2},
-        {"loss_function": 1, "loss_per_hour": -1},
-        {"loss_function": 2, "loss_per_hour": 10001},
-        {"loss_function": 2, "loss_per_hour": -1},
+        {"fit_to_limit": False, "energy_rate_decrease_per_update": 3}
     ])
     def test_storage_device_setting_fails(failing_arguments):
         """The storage validation fails when incompatible arguments are provided."""


### PR DESCRIPTION
The "loss per hour" mechanism is being deprecated, so this PR removes all validations involving it.

## Reference

- gridsingularity/gsy-e#1357