### PR TITLE
GSYE-154: Add 'traded_energy' member to the 'Trade' dataclass

### DIFF
--- a/gsy_framework/data_classes.py
+++ b/gsy_framework/data_classes.py
@@ -306,7 +306,9 @@ class TradeBidOfferInfo:
 class Trade:
     """Trade class."""
     def __init__(self, id: str, creation_time: DateTime, offer_bid: Union[Offer, Bid],
-                 seller: str, buyer: str, residual: Optional[Union[Offer, Bid]] = None,
+                 seller: str, buyer: str,
+                 traded_energy: float, trade_price: float,
+                 residual: Optional[Union[Offer, Bid]] = None,
                  already_tracked: bool = False,
                  offer_bid_trade_info: Optional[TradeBidOfferInfo] = None,
                  seller_origin: Optional[str] = None, buyer_origin: Optional[str] = None,
@@ -320,6 +322,8 @@ class Trade:
         self.offer_bid = offer_bid
         self.seller = seller
         self.buyer = buyer
+        self.traded_energy = traded_energy
+        self.trade_price = trade_price
         self.residual = residual
         self.already_tracked = already_tracked
         self.offer_bid_trade_info = offer_bid_trade_info
@@ -334,8 +338,8 @@ class Trade:
     def __str__(self) -> str:
         return (
             f"{{{self.id!s:.6s}}} [origin: {self.seller_origin} -> {self.buyer_origin}] "
-            f"[{self.seller} -> {self.buyer}] {self.offer_bid.energy} kWh @ {self.offer_bid.price}"
-            f" {round(self.offer_bid.energy_rate, 8)} "
+            f"[{self.seller} -> {self.buyer}] {self.traded_energy} kWh @ {self.trade_price}"
+            f" {round(self.trade_rate, 8)} "
             f"{self.offer_bid.id} [fee: {self.fee_price} cts.]")
 
     @classmethod
@@ -345,8 +349,8 @@ class Trade:
 
     def csv_values(self) -> Tuple:
         """Return values of class members that are needed for creation of CSV export."""
-        rate = round(self.offer_bid.energy_rate, 4)
-        return self.creation_time, rate, self.offer_bid.energy, self.seller, self.buyer
+        rate = round(self.trade_rate, 4)
+        return self.creation_time, rate, self.traded_energy, self.seller, self.buyer
 
     def to_json_string(self) -> str:
         """Return json string of the representation."""
@@ -388,6 +392,11 @@ class Trade:
         """Check if the instance is an offer trade."""
         return isinstance(self.offer_bid, Offer)
 
+    @property
+    def trade_rate(self):
+        """Return the energy rate of the trade."""
+        return round(self.trade_price / self.traded_energy, 8)
+
     def serializable_dict(self) -> Dict:
         """Return a json serializable representation of the class."""
         return {
@@ -396,9 +405,9 @@ class Trade:
             "id": self.id,
             "offer_bid_id": self.offer_bid.id,
             "residual_id": self.residual.id if self.residual is not None else None,
-            "energy": self.offer_bid.energy,
-            "energy_rate": self.offer_bid.energy_rate,
-            "price": self.offer_bid.price,
+            "energy": self.traded_energy,
+            "energy_rate": self.trade_rate,
+            "price": self.trade_price,
             "buyer": self.buyer,
             "buyer_origin": self.buyer_origin,
             "seller_origin": self.seller_origin,
@@ -418,6 +427,8 @@ class Trade:
             self.creation_time == other.creation_time and
             self.time_slot == other.time_slot and
             self.offer_bid == other.offer_bid and
+            self.traded_energy == other.traded_energy and
+            self.trade_price == other.trade_price and
             self.seller == other.seller and
             self.buyer == other.buyer and
             self.residual == other.residual and
@@ -450,8 +461,8 @@ class BalancingTrade(Trade):
     def __str__(self) -> str:
         return (
             f"{{{self.id!s:.6s}}} [{self.seller} -> {self.buyer}] "
-            f"{self.offer_bid.energy} kWh @ {self.offer_bid.price}"
-            f" {self.offer_bid.energy_rate} {self.offer_bid.id}"
+            f"{self.traded_energy} kWh @ {self.trade_price}"
+            f" {self.trade_rate} {self.offer_bid.id}"
         )
 
 

--- a/gsy_framework/data_classes.py
+++ b/gsy_framework/data_classes.py
@@ -29,6 +29,7 @@ from typing import List, Dict, Optional, Tuple, Union
 
 from pendulum import DateTime
 
+from gsy_framework.constants_limits import DEFAULT_PRECISION
 from gsy_framework.utils import (
     limit_float_precision, datetime_to_string_incl_seconds, key_in_dict_and_not_none,
     str_to_pendulum_datetime)
@@ -395,7 +396,7 @@ class Trade:
     @property
     def trade_rate(self):
         """Return the energy rate of the trade."""
-        return round(self.trade_price / self.traded_energy, 8)
+        return round(self.trade_price / self.traded_energy, DEFAULT_PRECISION)
 
     def serializable_dict(self) -> Dict:
         """Return a json serializable representation of the class."""

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -503,14 +503,16 @@ class TestTrade:
             "creation_time": DEFAULT_DATETIME,
             "offer_bid": Offer("id", DEFAULT_DATETIME, 1, 2, "seller"),
             "seller": "seller",
-            "buyer": "buyer"}
+            "buyer": "buyer",
+            "traded_energy": 1,
+            "trade_price": 1}
 
     def test_str(self):
         trade = Trade(**self.initial_data)
         assert (str(trade) ==
                 f"{{{trade.id!s:.6s}}} [origin: {trade.seller_origin} -> {trade.buyer_origin}] "
-                f"[{trade.seller} -> {trade.buyer}] {trade.offer_bid.energy} kWh"
-                f" @ {trade.offer_bid.price} {round(trade.offer_bid.energy_rate, 8)} "
+                f"[{trade.seller} -> {trade.buyer}] {trade.traded_energy} kWh"
+                f" @ {trade.trade_price} {round(trade.trade_rate, 8)} "
                 f"{trade.offer_bid.id} [fee: {trade.fee_price} cts.]")
 
     @staticmethod
@@ -520,9 +522,9 @@ class TestTrade:
 
     def test_csv_values(self):
         trade = Trade(**self.initial_data)
-        rate = round(trade.offer_bid.energy_rate, 4)
+        rate = round(trade.trade_rate, 4)
         assert (trade.csv_values() ==
-                (trade.creation_time, rate, trade.offer_bid.energy, trade.seller, trade.buyer))
+                (trade.creation_time, rate, trade.traded_energy, trade.seller, trade.buyer))
 
     def test_to_json_string(self):
         trade = Trade(**self.initial_data)
@@ -598,6 +600,8 @@ class TestTrade:
                 "seller_id": "seller_id",
                 "buyer_id": "buyer_id",
                 "seller": "seller",
+                "traded_energy": 1,
+                "trade_price": 1,
                 "fee_price": 2,
                 "creation_time": DEFAULT_DATETIME,
                 "time_slot": DEFAULT_DATETIME
@@ -609,9 +613,9 @@ class TestTrade:
             "id": trade.id,
             "offer_bid_id": trade.offer_bid.id,
             "residual_id": trade.residual.id if trade.residual is not None else None,
-            "energy": trade.offer_bid.energy,
-            "energy_rate": trade.offer_bid.energy_rate,
-            "price": trade.offer_bid.price,
+            "energy": trade.traded_energy,
+            "energy_rate": trade.trade_rate,
+            "price": trade.trade_price,
             "buyer": trade.buyer,
             "buyer_origin": trade.buyer_origin,
             "seller_origin": trade.seller_origin,
@@ -660,8 +664,8 @@ class TestBalancingTrade(TestTrade):
         trade = BalancingTrade(**self.initial_data)
         assert (str(trade) ==
                 f"{{{trade.id!s:.6s}}} [{trade.seller} -> {trade.buyer}] "
-                f"{trade.offer_bid.energy} kWh @ {trade.offer_bid.price}"
-                f" {trade.offer_bid.energy_rate} {trade.offer_bid.id}")
+                f"{trade.traded_energy} kWh @ {trade.trade_price}"
+                f" {trade.trade_rate} {trade.offer_bid.id}")
 
 
 class TestClearing:


### PR DESCRIPTION
In order to know the traded energy, we used to get it from `trade.offer_bid.energy`.
However,`energy` and `price` members of the bid and offer instances aren't the absolute source of truth now because if they have requirements they will be prioritized.
This PR adds `traded_energy` and `trade_price` members to the Trade object, so from now on we should read these values.