### PR TITLE
GSYE-154: Add 'accumulated_grid_fees' property to the orders

### DIFF
--- a/gsy_framework/data_classes.py
+++ b/gsy_framework/data_classes.py
@@ -116,6 +116,11 @@ class BaseBidOffer:
             return Bid(**offer_bid_dict)
         assert False, "the type member needs to be set to one of ('Bid', 'Offer')."
 
+    @property
+    def accumulated_grid_fees(self):
+        """Return the accumulated grid fees alongside the path of the order."""
+        return 0
+
 
 class Offer(BaseBidOffer):
     """Offer class"""
@@ -191,6 +196,11 @@ class Offer(BaseBidOffer):
     def csv_fields(cls) -> Tuple:
         """Return labels for csv_values for CSV export."""
         return "creation_time", "rate [ct./kWh]", "energy [kWh]", "price [ct.]", "seller"
+
+    @property
+    def accumulated_grid_fees(self):
+        """Return the accumulated grid fees alongside the path of the offer."""
+        return self.original_price - self.price
 
     @staticmethod
     def copy(offer: "Offer") -> "Offer":
@@ -273,6 +283,11 @@ class Bid(BaseBidOffer):
     def csv_fields(cls) -> Tuple:
         """Return labels for csv_values for CSV export."""
         return "creation_time", "rate [ct./kWh]", "energy [kWh]", "price [ct.]", "buyer"
+
+    @property
+    def accumulated_grid_fees(self):
+        """Return the accumulated grid fees alongside the path of the bid."""
+        return self.price - self.original_price
 
     def __eq__(self, other) -> bool:
         return (self.id == other.id and

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -370,6 +370,10 @@ class TestOffer:
         second_offer = Offer.copy(offer)
         assert offer == second_offer
 
+    def test_accumulated_grid_fees(self):
+        offer = Offer(**self.initial_data)
+        assert offer.accumulated_grid_fees == offer.original_price - offer.price
+
 
 class TestBid:
     def setup_method(self):
@@ -475,6 +479,10 @@ class TestBid:
     def test_csv_fields():
         assert (Bid.csv_fields() ==
                 ("creation_time", "rate [ct./kWh]", "energy [kWh]", "price [ct.]", "buyer"))
+
+    def test_accumulated_grid_fees(self):
+        bid = Bid(**self.initial_data)
+        assert bid.accumulated_grid_fees == bid.price - bid.original_price
 
 
 class TestTradeBidOfferInfo:


### PR DESCRIPTION
The property is meant to keep track of the constant grid fees alongside the path of the orders