### PR TITLE
GSYE-269: Set an empty list as a default children in accumulated_trades

### DIFF
--- a/gsy_framework/sim_results/cumulative_grid_trades.py
+++ b/gsy_framework/sim_results/cumulative_grid_trades.py
@@ -192,11 +192,13 @@ class CumulativeGridTrades(ResultsBaseClass):
         Returns: None
         """
         current_child_uuids = [
-            c["uuid"] for c in accumulated_trades[area["uuid"]].get("children", [])
+            child["uuid"] for child in accumulated_trades[area["uuid"]].get("children", [])  or []
         ]
         for child in area.get("children", []):
             if child["uuid"] not in current_child_uuids:
-                accumulated_trades[area["uuid"]].setdefault("children", []).append(
+                if accumulated_trades[area["uuid"]].get("children") is None:
+                    accumulated_trades[area["uuid"]]["children"] = []
+                accumulated_trades[area["uuid"]]["children"].append(
                     self._generate_accumulated_trades_child_dict(
                         accumulated_trades, child
                     )

--- a/gsy_framework/sim_results/cumulative_grid_trades.py
+++ b/gsy_framework/sim_results/cumulative_grid_trades.py
@@ -192,7 +192,7 @@ class CumulativeGridTrades(ResultsBaseClass):
         Returns: None
         """
         current_child_uuids = [
-            child["uuid"] for child in accumulated_trades[area["uuid"]].get("children", [])  or []
+            child["uuid"] for child in accumulated_trades[area["uuid"]].get("children", []) or []
         ]
         for child in area.get("children", []):
             if child["uuid"] not in current_child_uuids:

--- a/gsy_framework/sim_results/cumulative_grid_trades.py
+++ b/gsy_framework/sim_results/cumulative_grid_trades.py
@@ -192,7 +192,7 @@ class CumulativeGridTrades(ResultsBaseClass):
         Returns: None
         """
         current_child_uuids = [
-            child["uuid"] for child in accumulated_trades[area["uuid"]].get("children", []) or []
+            child["uuid"] for child in accumulated_trades[area["uuid"]].get("children") or []
         ]
         for child in area.get("children", []):
             if child["uuid"] not in current_child_uuids:

--- a/gsy_framework/sim_results/cumulative_grid_trades.py
+++ b/gsy_framework/sim_results/cumulative_grid_trades.py
@@ -192,11 +192,11 @@ class CumulativeGridTrades(ResultsBaseClass):
         Returns: None
         """
         current_child_uuids = [
-            c["uuid"] for c in accumulated_trades[area["uuid"]]["children"]
+            c["uuid"] for c in accumulated_trades[area["uuid"]].get("children", [])
         ]
         for child in area.get("children", []):
             if child["uuid"] not in current_child_uuids:
-                accumulated_trades[area["uuid"]]["children"].append(
+                accumulated_trades[area["uuid"]].setdefault("children", []).append(
                     self._generate_accumulated_trades_child_dict(
                         accumulated_trades, child
                     )


### PR DESCRIPTION
This is a precautionary measure in a corner case of missing children key of area in accumulated_trades but the same time there are existed children in area configuration tree.