### PR TITLE
GSYE-260: Increased the frequency of refreshing JWT tokens

### DIFF
--- a/gsy_framework/client_connections/utils.py
+++ b/gsy_framework/client_connections/utils.py
@@ -77,7 +77,9 @@ class RestCommunicationMixin:
 
     def _create_jwt_refresh_timer(self, sim_api_domain_name):
         self.jwt_refresh_timer = RepeatingTimer(
-            JWT_TOKEN_EXPIRY_IN_SECS - 30, self._refresh_jwt_token, [sim_api_domain_name]
+            # By refreshing 3 times during the lifetime of a token,
+            # we assure that we always have a working JWT token.
+            JWT_TOKEN_EXPIRY_IN_SECS / 4, self._refresh_jwt_token, [sim_api_domain_name]
         )
         self.jwt_refresh_timer.daemon = True
         self.jwt_refresh_timer.start()


### PR DESCRIPTION
During my investigation, it turned out that the `RestCommunicationMixin._create_jwt_refresh_timer` thread is working fine.
The problem is that, before my change, it used to refresh tokens just `30` seconds before their expiration.

So, I guess that the related [issue](https://gridsingularity.atlassian.net/browse/GSYE-260) is talking about a situation which the gsy-e-sdk was not able to refresh the token in 30 seconds (probably because of network issues).

To address this problem, I suggest to increase the frequency of refreshing JWT tokens. For this purpose, I increased it to 3 times of refreshing during a tokens lifetime (48 * 3600 seconds) ~ refreshing every 12 hours.