### PR TITLE
GSYE-188: Renamed 'DeviceStatistics' to 'AssetStatistics'.

### DIFF
--- a/gsy_framework/schemas.py
+++ b/gsy_framework/schemas.py
@@ -199,7 +199,9 @@ class ResultsSchemas:
                                 "elapsed_time_seconds": {"type": "number"},
                                 "percentage_completed": {"type": "number"},
                             },
+                            # TODO: remove `device_statistics`; only kept for b-ward compatibility.
                             "device_statistics": {"type": "object"},
+                            "asset_statistics": {"type": "object"},
                             "energy_trade_profile": {"type": "object"},
                             "last_energy_trade_profile": {"type": "object"},
                             "last_device_statistics": {"type": "object"},

--- a/gsy_framework/sim_results/aggregate_results.py
+++ b/gsy_framework/sim_results/aggregate_results.py
@@ -20,17 +20,22 @@ from typing import Dict, List
 from gsy_framework.sim_results.area_throughput_stats import AreaThroughputStats
 from gsy_framework.sim_results.energy_trade_profile import EnergyTradeProfile
 from gsy_framework.sim_results.market_price_energy_day import MarketPriceEnergyDay
-from gsy_framework.sim_results.device_statistics import DeviceStatistics
+from gsy_framework.sim_results.asset_statistics import AssetStatistics
 from gsy_framework.sim_results.market_summary_info import MarketSummaryInfo
 
 
-REQUESTED_FIELDS_LIST = ["price_energy_day", "device_statistics",
-                         "energy_trade_profile", "area_throughput", "market_summary"]
+REQUESTED_FIELDS_LIST = [
+    "price_energy_day", "asset_statistics",
+    "energy_trade_profile", "area_throughput",
+    "market_summary"
+]
 
 
 REQUESTED_FIELDS_CLASS_MAP = {
     "price_energy_day": MarketPriceEnergyDay,
-    "device_statistics": DeviceStatistics,
+    # TODO: remove `device_statistics`; It's only kept for backward compatibility.
+    "device_statistics": AssetStatistics,
+    "asset_statistics": AssetStatistics,
     "energy_trade_profile": EnergyTradeProfile,
     "area_throughput": AreaThroughputStats,
     "market_summary": MarketSummaryInfo
@@ -48,5 +53,9 @@ def merge_last_market_results_to_global(
         global_results[field] = REQUESTED_FIELDS_CLASS_MAP[field].merge_results_to_global(
             market_results[field], global_results[field], slot_list_ui_format
         )
+
+    # TODO: remove `device_statistics`; It's only kept for backward compatibility.
+    if "asset_statistics" in requested_fields:
+        global_results['device_statistics'] = global_results['asset_statistics']
 
     return global_results

--- a/gsy_framework/sim_results/all_results.py
+++ b/gsy_framework/sim_results/all_results.py
@@ -7,7 +7,7 @@ from gsy_framework.sim_results.area_throughput_stats import AreaThroughputStats
 from gsy_framework.sim_results.bills import MarketEnergyBills, CumulativeBills
 from gsy_framework.sim_results.cumulative_grid_trades import CumulativeGridTrades
 from gsy_framework.sim_results.cumulative_net_energy_flow import CumulativeNetEnergyFlow
-from gsy_framework.sim_results.device_statistics import DeviceStatistics
+from gsy_framework.sim_results.asset_statistics import AssetStatistics
 from gsy_framework.sim_results.energy_trade_profile import EnergyTradeProfile
 from gsy_framework.sim_results.kpi import KPI
 from gsy_framework.sim_results.market_price_energy_day import MarketPriceEnergyDay
@@ -26,12 +26,15 @@ class ResultsHandler:
             'price_energy_day': MarketPriceEnergyDay(should_export_plots),
             'cumulative_bills': CumulativeBills(),
             'cumulative_grid_trades': CumulativeGridTrades(),
-            'device_statistics': DeviceStatistics(should_export_plots),
+            'asset_statistics': AssetStatistics(should_export_plots),
             'trade_profile': EnergyTradeProfile(should_export_plots),
             'area_throughput': AreaThroughputStats(),
             'market_summary': MarketSummaryInfo(should_export_plots),
             'assets_info': SimulationAssetsInfo()
         }
+
+        # TODO: remove `device_statistics`; It's only kept for backward compatibility.
+        self.results_mapping['device_statistics'] = self.results_mapping['asset_statistics']
         self._total_memory_utilization_kb = 0.0
 
     @property

--- a/gsy_framework/sim_results/asset_statistics.py
+++ b/gsy_framework/sim_results/asset_statistics.py
@@ -27,7 +27,8 @@ from gsy_framework.utils import create_or_update_subdict, limit_float_precision
 FILL_VALUE = None
 
 
-class DeviceStatistics(ResultsBaseClass):
+class AssetStatistics(ResultsBaseClass):
+    # The words `Asset` and `Device` are used interchangeably.
 
     def __init__(self, should_export_plots):
         self.device_stats_dict = {}

--- a/tests/test_results_validator.py
+++ b/tests/test_results_validator.py
@@ -33,7 +33,10 @@ class TestValidateResults(unittest.TestCase):
                         "eta_seconds": 0,
                         "elapsed_time_seconds": 0,
                         "percentage_completed": 0
-                    }
+                    },
+                   # TODO: remove `device_statistics`; It's only kept for backward compatibility.
+                   "device_statistics": {},
+                   "asset_statistics": {}
         }
         results_validator(results)
 
@@ -45,7 +48,9 @@ class TestValidateResults(unittest.TestCase):
                     'cumulative_grid_trades': {},
                     'bills': {},
                     'cumulative_bills': {},
+                    # TODO: remove `device_statistics`; It's only kept for backward compatibility.
                     'device_statistics': {},
+                    'asset_statistics': {},
                     'energy_trade_profile': {}
                     }
         self.assertRaises(ValidationError, results_validator, results)
@@ -58,7 +63,9 @@ class TestValidateResults(unittest.TestCase):
                     'cumulative_bills': {},
                     'progress_info': {},
                     'status': 'running',
+                    # TODO: remove `device_statistics`; It's only kept for backward compatibility.
                     'device_statistics': {},
+                    'asset_statistics': {},
                     'not_a_parameter': {}
                     }
         self.assertRaises(ValidationError, results_validator, results)


### PR DESCRIPTION
Hi,
As requested by [GSYE-188](https://gridsingularity.atlassian.net/browse/GSYE-188), we have to rename `device_statistics.json` to `asset_statistics.json` in gsy-e and gsy-web exports.

As there's no straightforward way to do this, we have to start our changes from gsy-framework to gsy-web and gsy-e while keeping backward compatibility.

In this PR, I have added `asset_statistics` alongside `device_statistics` to gsy-framework results, so hopefully I can change gsy-e/web, and fully remove `device_statistics` in the future.

Also, I have marked all occurrences of `device_statistics` with #TODO tags in order to remove them later.

Thanks

