### PR TITLE
GSYE-278: Return early in KPI._post_process_savings_kpis if parent uu…

### DIFF
--- a/gsy_framework/sim_results/kpi.py
+++ b/gsy_framework/sim_results/kpi.py
@@ -357,13 +357,7 @@ class KPI(ResultsBaseClass):
             2. calculate base_case_cost, saving_absolute, saving_percentage for the area and
                add them to the self.performance_indices
         """
-        if not area_dict.get("children"):
-            return
-        if not area_dict.get("parent_uuid"):
-            # savings KPIs for the root area are not of interest and are removed
-            self.performance_indices[area_dict["uuid"]].pop("utility_bill", None)
-            self.performance_indices[area_dict["uuid"]].pop("fit_revenue", None)
-            self.performance_indices[area_dict["uuid"]].pop("gsy_e_cost", None)
+        if not area_dict.get("children") or area_dict["uuid"] not in self.savings_state:
             return
 
         for child in area_dict["children"]:


### PR DESCRIPTION
…id not in self.saving_state

Reason for this change is the following error that appears on dev and staging that is not reproducible locally:
```
ERROR 2022-05-05 08:00:12,694 redis_results_subscription 1 140681341331264 Simulation results handling for job id 
fe6a8621-0e5f-4be6-a92f-bccfbd0172c8 failed with an error: unsupported operand type(s) for +=: 'NoneType' and 'float' 
Traceback (most recent call last):   File "/app/simulation_results/redis_results_subscription.py", line 52, in 
_simulation_results_handler     self.results_calculation.update_simulation_result(message)   File 
"/app/simulation_results/results_calculation_helper.py", line 38, in update_simulation_result     
self._calculate_current_market_sim_results(data)   File "/app/simulation_results/results_calculation_helper.py", line 79, in 
_calculate_current_market_sim_results     self.simulation_results[data["job_id"]].update(config_tree, core_stats, 
current_market_ts)   File "/usr/local/lib/python3.8/site-packages/gsy_framework/sim_results/all_results.py", line 64, in 
update     result_object.update(area_dict, core_stats, current_market_slot)   File "/usr/local/lib/python3.8/site-
packages/gsy_framework/sim_results/kpi.py", line 346, in update     self.update(child, core_stats, current_market_slot)   File
 "/usr/local/lib/python3.8/site-packages/gsy_framework/sim_results/kpi.py", line 348, in update     
self._post_process_savings_kpis(area_dict)   File "/usr/local/lib/python3.8/site-packages/gsy_framework/sim_results/kpi.py",
 line 371, in _post_process_savings_kpis     self.performance_indices[area_dict["uuid"]]["utility_bill"] += ( TypeError:
 unsupported operand type(s) for +=: 'NoneType' and 'float'

```

I could not find out how there could be a case where the area is not part of the self.savings_state but its children are. 
I ran the connected integration tests and they pass. Let's see whether the savings KPIs still make sense for the affected simulations.