### PR TITLE
GSYE-278: Fix KPI.restore_area_results_state for case when savings_KP…

### DIFF
--- a/gsy_framework/sim_results/kpi.py
+++ b/gsy_framework/sim_results/kpi.py
@@ -405,12 +405,12 @@ class KPI(ResultsBaseClass):
         if area_dict["uuid"] not in self.savings_state:
             self.savings_state[area_dict["uuid"]] = SavingsKPI()
             self.savings_state[area_dict["uuid"]].utility_bill = (
-                last_known_state_data.get("utility_bill", 0))
+                last_known_state_data.get("utility_bill", 0)) or 0
             self.savings_state[area_dict["uuid"]].fit_revenue = (
-                last_known_state_data.get("fit_revenue", 0))
+                last_known_state_data.get("fit_revenue", 0)) or 0
             self.savings_state[area_dict["uuid"]].gsy_e_cost = (
                 last_known_state_data.get("gsy_e_cost", 0)
-                or last_known_state_data.get("d3a_cost", 0))
+                or last_known_state_data.get("d3a_cost", 0)) or 0
 
     @staticmethod
     def merge_results_to_global(market_device: Dict, global_device: Dict, *_):


### PR DESCRIPTION
…I states are None

The original error persists on dev:
```
ERROR 2022-05-05 08:00:12,694 redis_results_subscription 1 140681341331264 Simulation results handling for job id 
fe6a8621-0e5f-4be6-a92f-bccfbd0172c8 failed with an error: unsupported operand type(s) for +=: 'NoneType' and 'float' 
Traceback (most recent call last):   File "/app/simulation_results/redis_results_subscription.py", line 52, in 
_simulation_results_handler     self.results_calculation.update_simulation_result(message)   File 
"/app/simulation_results/results_calculation_helper.py", line 38, in update_simulation_result     
self._calculate_current_market_sim_results(data)   File "/app/simulation_results/results_calculation_helper.py", line 79, in 
_calculate_current_market_sim_results     self.simulation_results[data["job_id"]].update(config_tree, core_stats, 
current_market_ts)   File "/usr/local/lib/python3.8/site-packages/gsy_framework/sim_results/all_results.py", line 64, in 
update     result_object.update(area_dict, core_stats, current_market_slot)   File "/usr/local/lib/python3.8/site-
packages/gsy_framework/sim_results/kpi.py", line 346, in update     self.update(child, core_stats, current_market_slot)   File
 "/usr/local/lib/python3.8/site-packages/gsy_framework/sim_results/kpi.py", line 348, in update     
self._post_process_savings_kpis(area_dict)   File "/usr/local/lib/python3.8/site-packages/gsy_framework/sim_results/kpi.py",
 line 371, in _post_process_savings_kpis     self.performance_indices[area_dict["uuid"]]["utility_bill"] += ( TypeError:
 unsupported operand type(s) for +=: 'NoneType' and 'float'
```
The error seems to be originating from CNs where we restore a state from the DB for calculating the savings_KPI. If this state is set to None, the error occurs.

This PR changes the behaviour to write 0 for the case when the state is None. 