### PR TITLE
GSYE-269: Revert unneeded children key assignment in accumulated_trades

### DIFF
--- a/gsy_framework/sim_results/cumulative_grid_trades.py
+++ b/gsy_framework/sim_results/cumulative_grid_trades.py
@@ -196,8 +196,6 @@ class CumulativeGridTrades(ResultsBaseClass):
         ]
         for child in area.get("children", []):
             if child["uuid"] not in current_child_uuids:
-                if accumulated_trades[area["uuid"]].get("children") is None:
-                    accumulated_trades[area["uuid"]]["children"] = []
                 accumulated_trades[area["uuid"]]["children"].append(
                     self._generate_accumulated_trades_child_dict(
                         accumulated_trades, child


### PR DESCRIPTION
The previous fix was only making the corrupted CN work, but is not needed for non-corrupted simulations. The code from this fix was also populating incorrect value for `cumulative_grid_trades` and caused problems later with `readSimulationResultsQuery`.