### PR TITLE
Implement new tests for read_user_profile

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -474,7 +474,8 @@ name-group=
 
 # Regular expression which should only match function or class names that do
 # not require a docstring.
-no-docstring-rgx=^_
+no-docstring-rgx=^_|^test_|^Test|^step_impl|^setup_method|^teardown_method
+
 
 # List of decorators that produce properties, such as abc.abstractproperty. Add
 # to this list to register other decorators that produce valid properties.

--- a/tests/test_read_user_profile.py
+++ b/tests/test_read_user_profile.py
@@ -15,19 +15,16 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
-# pylint: disable=missing-function-docstring
-import unittest
-
 from pendulum import datetime, duration, today
 
-from gsy_framework.constants_limits import GlobalConfig, TIME_ZONE, PROFILE_EXPANSION_DAYS
+from gsy_framework.constants_limits import PROFILE_EXPANSION_DAYS, TIME_ZONE, GlobalConfig
 from gsy_framework.read_user_profile import (
-    _generate_slot_based_zero_values_dict_from_profile, read_arbitrary_profile, InputProfileTypes,
-    _fill_gaps_in_profile, _interpolate_profile_values_to_slot, read_profile_without_config)
+    InputProfileTypes, _fill_gaps_in_profile, _generate_slot_based_zero_values_dict_from_profile,
+    _interpolate_profile_values_to_slot, read_arbitrary_profile, read_profile_without_config)
 from gsy_framework.unit_test_utils import assert_dicts_identical
 
 
-class TestReadUserProfile(unittest.TestCase):
+class TestReadUserProfile:
     """Test reading the user profiles."""
 
     @staticmethod

--- a/tests/test_read_user_profile.py
+++ b/tests/test_read_user_profile.py
@@ -15,14 +15,29 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
+import pytest
 from pendulum import datetime, duration, today
 
 from gsy_framework.constants_limits import PROFILE_EXPANSION_DAYS, TIME_ZONE, GlobalConfig
 from gsy_framework.read_user_profile import (
     InputProfileTypes, _fill_gaps_in_profile, _generate_slot_based_zero_values_dict_from_profile,
-    _interpolate_profile_values_to_slot, read_arbitrary_profile, read_profile_without_config,
-    read_and_convert_identity_profile_to_float)
+    _interpolate_profile_values_to_slot, read_and_convert_identity_profile_to_float,
+    read_arbitrary_profile, read_profile_without_config)
 from gsy_framework.unit_test_utils import assert_dicts_identical
+
+
+@pytest.fixture(name="set_is_canary_network")
+def set_is_canary_network_fixture():
+    """Change the GlobalConfig value and then restore it at the end of the test."""
+    original_value = None
+
+    def _setup(value):
+        nonlocal original_value
+        original_value = GlobalConfig.IS_CANARY_NETWORK
+        GlobalConfig.IS_CANARY_NETWORK = value
+
+    yield _setup
+    GlobalConfig.IS_CANARY_NETWORK = original_value
 
 
 class TestReadUserProfile:
@@ -108,30 +123,35 @@ class TestReadUserProfile:
         })
 
     @staticmethod
-    def test_read_arbitrary_profile_returns_profile_with_correct_time_expansion():
+    def test_read_arbitrary_profile_returns_correct_profile_in_canary_network(
+            set_is_canary_network):
+        set_is_canary_network(True)
         market_maker_rate = 30
-        if GlobalConfig.IS_CANARY_NETWORK:
-            GlobalConfig.sim_duration = duration(hours=3)
-            expected_last_time_slot = today(tz=TIME_ZONE).add(days=PROFILE_EXPANSION_DAYS - 1,
-                                                              hours=23, minutes=45)
-            mmr = read_arbitrary_profile(InputProfileTypes.IDENTITY, market_maker_rate)
-            assert list(mmr.keys())[-1] == expected_last_time_slot
-            GlobalConfig.sim_duration = duration(hours=30)
-            expected_last_time_slot = today(tz=TIME_ZONE).add(days=PROFILE_EXPANSION_DAYS - 1,
-                                                              hours=23, minutes=45)
-            mmr = read_arbitrary_profile(InputProfileTypes.IDENTITY, market_maker_rate)
-            assert list(mmr.keys())[-1] == expected_last_time_slot
-        else:
-            GlobalConfig.FUTURE_MARKET_DURATION_HOURS = 0
-            GlobalConfig.sim_duration = duration(hours=3)
-            mmr = read_arbitrary_profile(InputProfileTypes.IDENTITY, market_maker_rate)
-            assert (list(mmr.keys())[-1] - today(tz=TIME_ZONE)).days == 0
-            GlobalConfig.sim_duration = duration(hours=36)
-            mmr = read_arbitrary_profile(InputProfileTypes.IDENTITY, market_maker_rate)
-            assert (list(mmr.keys())[-1] - today(tz=TIME_ZONE)).days == 1
+        GlobalConfig.sim_duration = duration(hours=3)
+        expected_last_time_slot = today(tz=TIME_ZONE).add(days=PROFILE_EXPANSION_DAYS - 1,
+                                                          hours=23, minutes=45)
+        mmr = read_arbitrary_profile(InputProfileTypes.IDENTITY, market_maker_rate)
+        assert list(mmr.keys())[-1] == expected_last_time_slot
+        GlobalConfig.sim_duration = duration(hours=30)
+        expected_last_time_slot = today(tz=TIME_ZONE).add(days=PROFILE_EXPANSION_DAYS - 1,
+                                                          hours=23, minutes=45)
+        mmr = read_arbitrary_profile(InputProfileTypes.IDENTITY, market_maker_rate)
+        assert list(mmr.keys())[-1] == expected_last_time_slot
 
-            GlobalConfig.FUTURE_MARKET_DURATION_HOURS = 24
-            GlobalConfig.sim_duration = duration(hours=1)
-            mmr = read_arbitrary_profile(InputProfileTypes.IDENTITY, market_maker_rate)
-            time_diff = list(mmr.keys())[-1] - today(tz=TIME_ZONE)
-            assert time_diff.minutes == 45
+    @staticmethod
+    def test_read_arbitrary_profile_returns_correct_profile(set_is_canary_network):
+        set_is_canary_network(False)
+        market_maker_rate = 30
+        GlobalConfig.FUTURE_MARKET_DURATION_HOURS = 0
+        GlobalConfig.sim_duration = duration(hours=3)
+        mmr = read_arbitrary_profile(InputProfileTypes.IDENTITY, market_maker_rate)
+        assert (list(mmr.keys())[-1] - today(tz=TIME_ZONE)).days == 0
+        GlobalConfig.sim_duration = duration(hours=36)
+        mmr = read_arbitrary_profile(InputProfileTypes.IDENTITY, market_maker_rate)
+        assert (list(mmr.keys())[-1] - today(tz=TIME_ZONE)).days == 1
+
+        GlobalConfig.FUTURE_MARKET_DURATION_HOURS = 24
+        GlobalConfig.sim_duration = duration(hours=1)
+        mmr = read_arbitrary_profile(InputProfileTypes.IDENTITY, market_maker_rate)
+        time_diff = list(mmr.keys())[-1] - today(tz=TIME_ZONE)
+        assert time_diff.minutes == 45

--- a/tests/test_read_user_profile.py
+++ b/tests/test_read_user_profile.py
@@ -20,12 +20,21 @@ from pendulum import datetime, duration, today
 from gsy_framework.constants_limits import PROFILE_EXPANSION_DAYS, TIME_ZONE, GlobalConfig
 from gsy_framework.read_user_profile import (
     InputProfileTypes, _fill_gaps_in_profile, _generate_slot_based_zero_values_dict_from_profile,
-    _interpolate_profile_values_to_slot, read_arbitrary_profile, read_profile_without_config)
+    _interpolate_profile_values_to_slot, read_arbitrary_profile, read_profile_without_config,
+    read_and_convert_identity_profile_to_float)
 from gsy_framework.unit_test_utils import assert_dicts_identical
 
 
 class TestReadUserProfile:
     """Test reading the user profiles."""
+
+    @staticmethod
+    def test_read_and_convert_identity_profile_to_float():
+        profile = "30.4"
+        output_profile = read_and_convert_identity_profile_to_float(profile)
+        # All slots are generated (96 slots of 15 minutes each in one day)
+        assert len(output_profile) == 96
+        assert all(value == 30.4 for value in output_profile.values())
 
     @staticmethod
     def _validate_timedeltas_are_followed(profile):


### PR DESCRIPTION
- Add test for `read_and_convert_identity_profile_to_float()`
- Fix tests for `read_arbitrary_profile()` (half of the tests were not running because of the GlobalConfig setup)
- Add exceptions to pylintrc for test docstrings
- Do not use unittest classes for the test module