### PR TITLE
GSYE-159: Replace `energy_rate` with a property in BaseBidOffer

### DIFF
--- a/gsy_framework/data_classes.py
+++ b/gsy_framework/data_classes.py
@@ -53,19 +53,21 @@ class BaseBidOffer:
         self.original_price = original_price or price
         self.price = price
         self.energy = energy
-        self.energy_rate = limit_float_precision(self.price / self.energy)
         self.attributes = attributes
         self.requirements = requirements
+
+    @property
+    def energy_rate(self) -> float:
+        """Dynamically calculate rate of energy."""
+        return limit_float_precision(self.price / self.energy)
 
     def update_price(self, price: float) -> None:
         """Update price member."""
         self.price = price
-        self.energy_rate = limit_float_precision(self.price / self.energy)
 
     def update_energy(self, energy: float) -> None:
         """Update energy member."""
         self.energy = energy
-        self.energy_rate = limit_float_precision(self.price / self.energy)
 
     def to_json_string(self, **kwargs) -> str:
         """Convert the Offer or Bid object into its JSON representation.
@@ -544,8 +546,8 @@ class BidOfferMatch:
         """
         if "bid_requirement" in (self.matching_requirements or {}):
             return (
-                    self.matching_requirements["bid_requirement"].get("energy")
-                    or self.bid["energy"])
+                self.matching_requirements["bid_requirement"].get("energy")
+                or self.bid["energy"])
         return self.bid["energy"]
 
     @property
@@ -558,8 +560,8 @@ class BidOfferMatch:
         if "bid_requirement" in (self.matching_requirements or {}):
             if "price" in self.matching_requirements["bid_requirement"]:
                 return (
-                        self.matching_requirements["bid_requirement"].get("price") /
-                        self.bid_energy)
+                    self.matching_requirements["bid_requirement"].get("price") /
+                    self.bid_energy)
         return self.bid["energy_rate"]
 
 

--- a/gsy_framework/data_classes.py
+++ b/gsy_framework/data_classes.py
@@ -80,6 +80,7 @@ class BaseBidOffer:
             obj_dict = {**obj_dict, **kwargs}
 
         obj_dict["type"] = self.__class__.__name__
+        obj_dict["energy_rate"] = self.energy_rate
 
         return json.dumps(obj_dict, default=json_datetime_serializer)
 

--- a/gsy_framework/data_classes.py
+++ b/gsy_framework/data_classes.py
@@ -55,6 +55,7 @@ class BaseBidOffer:
         self.energy = energy
         self.attributes = attributes
         self.requirements = requirements
+        self.type = self.__class__.__name__
 
     @property
     def energy_rate(self) -> float:
@@ -79,15 +80,13 @@ class BaseBidOffer:
         if kwargs:
             obj_dict = {**obj_dict, **kwargs}
 
-        obj_dict["type"] = self.__class__.__name__
         obj_dict["energy_rate"] = self.energy_rate
-
         return json.dumps(obj_dict, default=json_datetime_serializer)
 
     def serializable_dict(self) -> Dict:
         """Return a json serializable representation of the class."""
         return {
-            "type": self.__class__.__name__,
+            "type": self.type,
             "id": self.id,
             "energy": self.energy,
             "energy_rate": self.energy_rate,

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -191,15 +191,20 @@ class TestBaseBidOffer:
         assert bid_offer.energy_rate == bid_offer.price / 40
 
     def test_to_json_string(self):
+        bid_offer_keys = {
+            "id", "creation_time", "time_slot", "original_price", "price", "energy", "attributes",
+            "requirements", "type", "energy_rate"}
         bid_offer = BaseBidOffer(
             **self.initial_data
         )
-        obj_dict = deepcopy(bid_offer.__dict__)
+        obj_dict = json.loads(bid_offer.to_json_string(my_extra_key=10))
+        assert obj_dict.pop("my_extra_key") == 10
+        assert set(obj_dict.keys()) == bid_offer_keys
 
-        obj_dict["type"] = "BaseBidOffer"
-        assert bid_offer.to_json_string() == json.dumps(obj_dict, default=json_datetime_serializer)
-        assert json.loads(
-            bid_offer.to_json_string(my_extra_key=10)).get("my_extra_key") == 10
+        assert json.dumps(obj_dict, sort_keys=True) == json.dumps(
+            {key: getattr(bid_offer, key) for key in bid_offer_keys}, sort_keys=True,
+            default=json_datetime_serializer
+        )
 
     def test_serializable_dict(self):
         bid_offer = BaseBidOffer(


### PR DESCRIPTION
## Reason for the proposed changes

According to [GSYE-159](https://gridsingularity.atlassian.net/browse/GSYE-159), in the past it was revealed that dynamically calculating `energy_rate` consumes a lot of CPU cycles, thus the decision was to pre-calculate and cache it. We guess the situation is different now and the frequency of using the `energy_rate` member has decreased, so we decided to replace it with a property to see if it has a significant increase in the simulation runtime. In case if an increase, it will be reverted.

## Proposed changes
- Replace `enerty_rate` member by a property
- Refactor `TestBaseBidOffer.test_to_json_string`
- Make Pylint happier!

INTEGRATION_TESTS_BRANCH=master
GSY_FRAMEWORK_BRANCH=master