### PR TITLE
GSYE-45: Deprecate AlternativePricing setting

### DIFF
--- a/gsy_framework/constants_limits.py
+++ b/gsy_framework/constants_limits.py
@@ -196,18 +196,6 @@ class ConstSettings:
         MIN_OFFER_AGE = 2
         MIN_BID_AGE = 2
 
-        class AlternativePricing:
-            """Default values for alternative pricing schemes."""
-
-            # Option 0: D3A_trading
-            # Option 1: no scheme (0 cents/kWh)
-            # Option 2: feed-in-tariff (FEED_IN_TARIFF_PERCENTAGE / 100 * MMR)
-            # Option 3: net-metering (MMR)
-            COMPARE_PRICING_SCHEMES = False
-            PRICING_SCHEME = 0
-            FEED_IN_TARIFF_PERCENTAGE = 50
-            ALT_PRICING_MARKET_MAKER_NAME = "AGENT"
-
     class BlockchainSettings:
         """Default settings for blockchain functionality."""
 


### PR DESCRIPTION
## Reason for the proposed changes
As requested by [GSYE-45](https://gridsingularity.atlassian.net/browse/GSYE-45), we wanted to deprecate the `--compare-alt-pricing` option and all of its related setting.

## Proposed changes
- Deprecate AlternativePricing setting