### PR TITLE
Move CloudCoverage enum to gsy-framework

### DIFF
--- a/gsy_framework/enums.py
+++ b/gsy_framework/enums.py
@@ -15,3 +15,14 @@ class SpotMarketTypeEnum(Enum):
     ONE_SIDED = 1
     TWO_SIDED = 2
     COEFFICIENTS = 3
+
+
+class CloudCoverage(Enum):
+    """Available cloud coverage options for PV assets."""
+
+    CLEAR = 0
+    PARTIAL_CLOUD = 1
+    CLOUDY = 2
+    GAUSSIAN = 3
+    UPLOAD_PROFILE = 4
+    LOCAL_GENERATION_PROFILE = 5  # Generate profiles using Rebase API


### PR DESCRIPTION
## Reason for the proposed changes

`CloudCoverage` will be re-used by the community datasheet importer in the context of GSYE-261. More specifically, `CloudCoverage.LOCAL_GENERATION_PROFILE` will be used to populate the value of `"cloud_coverage"` in PV representations when they don't explicitly provide energy profiles.

## Proposed changes

- Move `CloudCoverage` to gsy-framework

## Related PRs:

- https://github.com/gridsingularity/gsy-web/pull/1732
- https://github.com/gridsingularity/gsy-backend-integration-tests/pull/54