### PR TITLE
GSYE-364: Fix backports-entry-points-selectable==1.1.0 installation error

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,7 +6,7 @@
 #
 attrs==21.2.0
     # via jsonschema
-backports-entry-points-selectable==1.1.0
+backports.entry-points-selectable==1.1.0
     # via virtualenv
 certifi==2021.10.8
     # via requests

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -14,7 +14,7 @@ attrs==21.2.0
     #   hypothesis
     #   jsonschema
     #   pytest
-backports-entry-points-selectable==1.1.0
+backports.entry-points-selectable==1.1.0
     # via
     #   -r requirements/base.txt
     #   virtualenv


### PR DESCRIPTION
## Proposed Changes:
- Fix dependency name for backports-entry-points-selectable