### PR TITLE
Catch BadZipFile exception for datasheet unsupported xls files

### DIFF
--- a/gsy_framework/community_datasheet/community_datasheet_reader.py
+++ b/gsy_framework/community_datasheet/community_datasheet_reader.py
@@ -6,6 +6,7 @@ import pathlib
 from dataclasses import asdict, dataclass, field
 from itertools import chain
 from typing import IO, Dict, List, Union
+from zipfile import BadZipFile
 
 from openpyxl import load_workbook
 from openpyxl.utils.exceptions import InvalidFileException
@@ -122,7 +123,9 @@ class CommunityDatasheetReader:
     def _load_workbook(filename: Union[str, pathlib.Path, IO]):
         try:
             return load_workbook(filename, read_only=True)
-        except InvalidFileException as ex:
+        except (InvalidFileException, BadZipFile) as ex:
+            # NOTE: openpyxl does not support the old .xls file format.
+            # BadZipFile is raised when the InMemoryUploadedFile passed by Django is of type xls
             logger.debug("Error while parsing community datasheet: %s", ex)
             raise CommunityDatasheetException(
                 "Community Datasheet format not supported. "


### PR DESCRIPTION
openpyxl doesn't support old xls files:

> openpyxl.utils.exceptions.InvalidFileException: openpyxl does not support the old .xls file format, please use xlrd to read this file, or convert it to the more recent .xlsx file format.

Passing a "plain" xls file to openpyxl correctly raises the expected `InvalidFileException`. However, passing an instance of django's `InMemoryUploadedFile` that refers to an xls raises a `BadZipFile` exception instead.

This PR refactors the code so that this `BadZipFile` exception is caught, to show the proper error (not the “Server Error” we currently have).