### PR TITLE
GSYE-418: Fix SCMKPI raising KeyError exceptions for GridMarket

### DIFF
--- a/gsy_framework/sim_results/scm/kpi.py
+++ b/gsy_framework/sim_results/scm/kpi.py
@@ -17,7 +17,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 import logging
 from copy import copy
-from dataclasses import dataclass, asdict
+from dataclasses import asdict, dataclass
 from typing import Dict
 
 from gsy_framework.sim_results.results_abc import ResultsBaseClass
@@ -199,10 +199,15 @@ class SCMKPI(ResultsBaseClass):
         if not last_known_state_data:
             return
         if area_dict["uuid"] not in self._state:
+            # TODO: the following SCMKPIState arguments should be mandatory as soon as front-end
+            #  removed GridMarket from the scenario.
             self._state[area_dict["uuid"]] = SCMKPIState(
-                total_energy_demanded_wh=last_known_state_data["total_energy_demanded_wh"],
-                total_energy_produced_wh=last_known_state_data["total_energy_produced_wh"],
-                total_self_consumption_wh=last_known_state_data["total_self_consumption_wh"],
+                total_energy_demanded_wh=last_known_state_data.get(
+                    "total_energy_demanded_wh", 0) or 0,
+                total_energy_produced_wh=last_known_state_data.get(
+                    "total_energy_produced_wh", 0) or 0,
+                total_self_consumption_wh=last_known_state_data.get(
+                    "total_self_consumption_wh", 0) or 0,
                 total_base_energy_cost=last_known_state_data.get("total_base_energy_cost", 0) or 0,
                 total_fit_revenue=last_known_state_data.get("total_fit_revenue", 0) or 0,
                 total_gsy_e_cost=last_known_state_data.get("total_gsy_e_cost", 0) or 0,

--- a/gsy_framework/sim_results/scm/kpi.py
+++ b/gsy_framework/sim_results/scm/kpi.py
@@ -215,9 +215,9 @@ class SCMKPI(ResultsBaseClass):
                     "total_base_energy_cost_excl_revenue", 0) or 0,
                 total_gsy_e_cost_excl_revenue=last_known_state_data.get(
                     "total_gsy_e_cost_excl_revenue", 0) or 0,
-                energy_demanded_wh=last_known_state_data["energy_demanded_wh"],
-                energy_produced_wh=last_known_state_data["energy_produced_wh"],
-                self_consumption_wh=last_known_state_data["self_consumption_wh"],
+                energy_demanded_wh=last_known_state_data.get("energy_demanded_wh", 0) or 0,
+                energy_produced_wh=last_known_state_data.get("energy_produced_wh", 0) or 0,
+                self_consumption_wh=last_known_state_data.get("self_consumption_wh", 0) or 0,
                 base_energy_cost=last_known_state_data.get("base_energy_cost", 0) or 0,
                 base_energy_cost_excl_revenue=last_known_state_data.get(
                     "base_energy_cost_excl_revenue", 0) or 0,


### PR DESCRIPTION
As requested by [GSYE-418](https://gridsingularity.atlassian.net/browse/GSYE-418), the following KeyError is raised when calculating KPIs for the GridMarket.

Note: This is a temporary fix (That's why you see a #TODO) and all arguments of `SCMKPIState` should be mandatory as soon as frontend removed the `Grid Market` from the scenario. Also, gsy-web should take care of asserting that.

```python
Traceback (most recent call last):
  File "/app/simulation_results/redis_results_subscription.py", line 58, in _simulation_results_handler
    self.results_calculation.update_simulation_result(message)
  File "/app/simulation_results/results_calculation_helper.py", line 42, in update_simulation_result
    self._restore_state(data["configuration_tree"], data["job_id"])
  File "/app/simulation_results/results_calculation_helper.py", line 65, in _restore_state
    self.simulation_results[job_id].restore_area_results_state(
  File "/usr/local/lib/python3.8/site-packages/gsy_framework/sim_results/all_results.py", line 100, in restore_area_results_state
    result_object.restore_area_results_state(
  File "/usr/local/lib/python3.8/site-packages/gsy_framework/sim_results/scm/kpi.py", line 203, in restore_area_results_state
    total_energy_demanded_wh=last_known_state_data["total_energy_demanded_wh"],
KeyError: 'total_energy_demanded_wh'
```

## Steps to reproduction:
1- Start a SCM canary network
2- Stop it after a couple of slots
3- Start it again
