### PR TITLE
feature/GSYE-414: Add calculatation of price profile graph

### DIFF
--- a/gsy_framework/sim_results/electric_blue/aggregate_results.py
+++ b/gsy_framework/sim_results/electric_blue/aggregate_results.py
@@ -130,6 +130,20 @@ class ForwardDeviceStats:  # pylint: disable=too-many-instance-attributes
         assert offer["seller_id"] == self.device_uuid, "Device is not seller of the offer."
         self.open_offers.append(offer)
 
+    @property
+    def average_sell_price(self) -> float:
+        """Return average sell price for the timeslot."""
+        if self.total_energy_sold == 0:
+            return 0
+        return self.total_earned_eur / self.total_energy_sold
+
+    @property
+    def average_buy_price(self) -> float:
+        """Return average buy price for the timeslot."""
+        if self.total_energy_bought == 0:
+            return 0
+        return self.total_spent_eur / self.total_energy_bought
+
 
 def handle_forward_results(
         current_time_slot: DateTime, market_stats: Dict[str, Dict[str, List]]) -> Dict:

--- a/gsy_framework/sim_results/electric_blue/aggregate_results.py
+++ b/gsy_framework/sim_results/electric_blue/aggregate_results.py
@@ -131,14 +131,14 @@ class ForwardDeviceStats:  # pylint: disable=too-many-instance-attributes
         self.open_offers.append(offer)
 
     @property
-    def average_sell_price(self) -> float:
+    def average_sell_rate(self) -> float:
         """Return average sell price for the timeslot."""
         if self.total_energy_sold == 0:
             return 0
         return self.total_earned_eur / self.total_energy_sold
 
     @property
-    def average_buy_price(self) -> float:
+    def average_buy_rate(self) -> float:
         """Return average buy price for the timeslot."""
         if self.total_energy_bought == 0:
             return 0

--- a/gsy_framework/sim_results/electric_blue/aggregate_results.py
+++ b/gsy_framework/sim_results/electric_blue/aggregate_results.py
@@ -53,12 +53,14 @@ class ForwardDeviceStats:  # pylint: disable=too-many-instance-attributes
     total_sell_trade_count: int = 0
     total_energy_sold: float = 0
     total_earned_eur: float = 0
+    accumulated_sell_trade_rates: float = 0
 
     # BUYER
     total_energy_consumed: float = 0
     total_buy_trade_count: int = 0
     total_energy_bought: float = 0
     total_spent_eur: float = 0
+    accumulated_buy_trade_rates: float = 0
 
     def __post_init__(self):
         """Creates non-field attributes for the objects which are needed for further
@@ -94,6 +96,10 @@ class ForwardDeviceStats:  # pylint: disable=too-many-instance-attributes
             total_buy_trade_count=self.total_buy_trade_count + other.total_buy_trade_count,
             total_energy_bought=self.total_energy_bought + other.total_energy_bought,
             total_spent_eur=self.total_spent_eur + other.total_spent_eur,
+            accumulated_buy_trade_rates=(self.accumulated_buy_trade_rates +
+                                         other.accumulated_buy_trade_rates),
+            accumulated_sell_trade_rates=(self.accumulated_sell_trade_rates +
+                                          other.accumulated_sell_trade_rates)
         )
         forward_device_stats.open_bids = open_bids
         forward_device_stats.open_offers = open_offers
@@ -111,10 +117,12 @@ class ForwardDeviceStats:  # pylint: disable=too-many-instance-attributes
             self.total_sell_trade_count += 1
             self.total_energy_sold += trade["energy"]
             self.total_earned_eur += trade["price"]
+            self.accumulated_sell_trade_rates += trade["energy_rate"]
         elif trade["buyer_id"] == self.device_uuid:
             self.total_buy_trade_count += 1
             self.total_energy_bought += trade["energy"]
             self.total_spent_eur += trade["price"]
+            self.accumulated_buy_trade_rates += trade["energy_rate"]
         else:
             raise AssertionError("Device is not seller/buyer of the trade.")
 
@@ -133,16 +141,16 @@ class ForwardDeviceStats:  # pylint: disable=too-many-instance-attributes
     @property
     def average_sell_rate(self) -> float:
         """Return average sell price for the timeslot."""
-        if self.total_energy_sold == 0:
+        if self.total_sell_trade_count == 0:
             return 0
-        return self.total_earned_eur / self.total_energy_sold
+        return self.accumulated_sell_trade_rates / self.total_sell_trade_count
 
     @property
     def average_buy_rate(self) -> float:
         """Return average buy price for the timeslot."""
-        if self.total_energy_bought == 0:
+        if self.total_buy_trade_count == 0:
             return 0
-        return self.total_spent_eur / self.total_energy_bought
+        return self.accumulated_buy_trade_rates / self.total_buy_trade_count
 
 
 def handle_forward_results(

--- a/gsy_framework/sim_results/electric_blue/timeseries_base.py
+++ b/gsy_framework/sim_results/electric_blue/timeseries_base.py
@@ -1,0 +1,61 @@
+import abc
+from typing import Dict, Optional
+
+from pendulum import DateTime
+
+from gsy_framework.enums import AggregationResolution, AvailableMarketTypes
+from gsy_framework.sim_results.electric_blue.aggregate_results import (
+    ForwardDeviceStats)
+
+# a dictionary showing the start of time slot for each resolution.
+START_OF = {
+    AggregationResolution.RES_1_HOUR: "hour",
+    AggregationResolution.RES_1_WEEK: "week",
+    AggregationResolution.RES_1_MONTH: "month",
+    AggregationResolution.RES_1_YEAR: "year",
+}
+
+
+class AssetTimeSeriesBase(abc.ABC):
+    """Base class for calculating different timeseries for forward markets."""
+    def __init__(self, asset_uuid: str, resolution: AggregationResolution):
+        self.asset_uuid = asset_uuid
+        self.resolution = resolution
+        self._asset_time_series_buffer: Dict[DateTime, Dict] = {}
+
+    @abc.abstractmethod
+    def update_time_series(
+            self, asset_stats: ForwardDeviceStats, product_type: AvailableMarketTypes):
+        """Update asset volume time series with the current asset stats: stats from the last 15
+        minutes."""
+
+    @abc.abstractmethod
+    def save_time_series(self):
+        """Save asset volume time series in the DB."""
+
+    @abc.abstractmethod
+    def _fetch_asset_time_series_from_db(
+            self, year: DateTime) -> Optional[Dict[str, Dict]]:
+        """Fetch already saved asset volume time series."""
+
+    @abc.abstractmethod
+    def _generate_time_series(self, year):
+        """Generate time series for the asset."""
+
+    def _adapt_time_slot(self, time_slot: DateTime) -> DateTime:
+        """Adapt given time_slot with time series resolution."""
+        if self.resolution == AggregationResolution.RES_15_MINUTES:
+            return time_slot.set(minute=(time_slot.minute // 15) * 15)
+        return time_slot.start_of(START_OF[self.resolution])
+
+    def _get_asset_time_series(self, year: DateTime) -> Dict[str, Dict]:
+        """Return asset volume time series for the required year.
+        If not found in the buffer, it tries fetching it from DB.
+        If not found in the DB, it will generate a new one for the whole year."""
+        if year in self._asset_time_series_buffer:
+            time_series = self._asset_time_series_buffer[year]
+        else:
+            time_series = self._fetch_asset_time_series_from_db(year)
+            if time_series is None:
+                time_series = self._generate_time_series(year)
+        return time_series

--- a/gsy_framework/sim_results/electric_blue/volume_timeseries.py
+++ b/gsy_framework/sim_results/electric_blue/volume_timeseries.py
@@ -24,24 +24,45 @@ class AssetVolumeTimeSeries(AssetTimeSeriesBase):
     {
         DateTime(2020, 1, 1, 0, 0, 0): {
             DateTime(2020, 1, 1, 0, 0, 0): {
-                "SSP": 1005.4160297565659,
-                "YEAR_FORWARD": {
-                    "bought_kWh": 201.08320595131318,
-                    "sold_kWh": 201.08320595131318,
+                'DAY_FORWARD': {
+                    'bought': {
+                        'energy_kWh': 0.0,
+                        'energy_rate': 0.0,
+                        'price': 0.0},
+                    'sold': {
+                        'energy_kWh': 0.0,
+                        'energy_rate': 0.0,
+                        'price': 0.0}
                 },
-                "MONTH_FORWARD": {
-                    "bought_kWh": 201.08320595131318,
-                    "sold_kWh": 201.08320595131318,
+                'MONTH_FORWARD': {
+                    'bought': {
+                        'energy_kWh': 402.132,
+                        'energy_rate': 0.3,
+                        'price': 120.28},
+                    'sold': {
+                        'energy_kWh': 402.132,
+                        'energy_rate': 0.45,
+                        'price': 181.97}
                 },
-                "WEEK_FORWARD": {
-                    "bought_kWh": 32.432775153437625,
-                    "sold_kWh": 32.432775153437625,
-                },
-                "DAY_FORWARD": {
-                    "bought_kWh": 6.486555030687522,
-                    "sold_kWh": 6.486555030687522,
-                },
-            },
+                'SSP': 201.08320595131318,
+                'WEEK_FORWARD': {
+                    'bought': {
+                        'energy_kWh': 0.0,
+                        'energy_rate': 0.0,
+                        'price': 0.0},
+                    'sold': {
+                        'energy_kWh': 0.0,
+                        'energy_rate': 0.0,
+                        'price': 0.0}},
+                'YEAR_FORWARD': {
+                    'bought': {
+                        'energy_kWh': 0.0,
+                        'energy_rate': 0.0,
+                        'price': 0.0},
+                    'sold': {
+                        'energy_kWh': 0.0,
+                        'energy_rate': 0.0,
+                        'price': 0.0}}},
             DateTime(2020, 2, 1, 0, 0, 0): {...},
             ...
             DateTime(2020, 12, 1, 0, 0, 0): {...},

--- a/gsy_framework/sim_results/electric_blue/volume_timeseries.py
+++ b/gsy_framework/sim_results/electric_blue/volume_timeseries.py
@@ -102,13 +102,13 @@ class AssetVolumeTimeSeries(AssetTimeSeriesBase):
             return
         profile = self._trade_profile_generator.generate_trade_profile(
             energy_kWh, asset_stats.time_slot, product_type)
-        average_buy_price = asset_stats.average_buy_price
+        average_buy_rate = asset_stats.average_buy_rate
         for time_slot, energy in profile.items():
             self._add_to_volume_time_series(
                 time_slot,
                 {
                     "energy_kWh": energy,
-                    "price": energy * average_buy_price
+                    "price": energy * average_buy_rate
                 }, product_type, "bought")
 
     def _add_total_energy_sold(
@@ -120,13 +120,13 @@ class AssetVolumeTimeSeries(AssetTimeSeriesBase):
         profile = self._trade_profile_generator.generate_trade_profile(
             energy_kWh, asset_stats.time_slot, product_type
         )
-        average_sell_price = asset_stats.average_sell_price
+        average_sell_rate = asset_stats.average_sell_rate
         for time_slot, energy in profile.items():
             self._add_to_volume_time_series(
                 time_slot,
                 {
                     "energy_kWh": energy,
-                    "price": energy * average_sell_price
+                    "price": energy * average_sell_rate
                 }, product_type, "sold")
 
     def _add_to_volume_time_series(

--- a/gsy_framework/sim_results/electric_blue/volume_timeseries.py
+++ b/gsy_framework/sim_results/electric_blue/volume_timeseries.py
@@ -26,43 +26,49 @@ class AssetVolumeTimeSeries(AssetTimeSeriesBase):
             DateTime(2020, 1, 1, 0, 0, 0): {
                 'DAY_FORWARD': {
                     'bought': {
-                        'energy_kWh': 0.0,
-                        'energy_rate': 0.0,
-                        'price': 0.0},
+                        "energy_kWh": 0.0,
+                        "energy_rate": 0.0,
+                        "trade_count": 0,
+                        "accumulated_trade_rates": 0.0},
                     'sold': {
-                        'energy_kWh': 0.0,
-                        'energy_rate': 0.0,
-                        'price': 0.0}
-                },
+                        "energy_kWh": 0.0,
+                        "energy_rate": 0.0,
+                        "trade_count": 0,
+                        "accumulated_trade_rates": 0.0}},
                 'MONTH_FORWARD': {
                     'bought': {
                         'energy_kWh': 402.132,
                         'energy_rate': 0.3,
-                        'price': 120.28},
+                        'trade_count': 2976,
+                        'accumulated_trade_rates': 892.8},
                     'sold': {
                         'energy_kWh': 402.132,
-                        'energy_rate': 0.45,
-                        'price': 181.97}
-                },
+                        'energy_rate': 0.3,
+                        'trade_count': 2976,
+                        'accumulated_trade_rates': 892.8}},
                 'SSP': 201.08320595131318,
                 'WEEK_FORWARD': {
                     'bought': {
-                        'energy_kWh': 0.0,
-                        'energy_rate': 0.0,
-                        'price': 0.0},
+                        "energy_kWh": 0.0,
+                        "energy_rate": 0.0,
+                        "trade_count": 0,
+                        "accumulated_trade_rates": 0.0},
                     'sold': {
-                        'energy_kWh': 0.0,
-                        'energy_rate': 0.0,
-                        'price': 0.0}},
+                        "energy_kWh": 0.0,
+                        "energy_rate": 0.0,
+                        "trade_count": 0,
+                        "accumulated_trade_rates": 0.0}},
                 'YEAR_FORWARD': {
                     'bought': {
-                        'energy_kWh': 0.0,
-                        'energy_rate': 0.0,
-                        'price': 0.0},
+                        "energy_kWh": 0.0,
+                        "energy_rate": 0.0,
+                        "trade_count": 0,
+                        "accumulated_trade_rates": 0.0},
                     'sold': {
-                        'energy_kWh': 0.0,
-                        'energy_rate': 0.0,
-                        'price': 0.0}}},
+                        "energy_kWh": 0.0,
+                        "energy_rate": 0.0,
+                        "trade_count": 0,
+                        "accumulated_trade_rates": 0.0}}},
             DateTime(2020, 2, 1, 0, 0, 0): {...},
             ...
             DateTime(2020, 12, 1, 0, 0, 0): {...},

--- a/tests/test_sim_results/electric_blue/test_aggregate_results.py
+++ b/tests/test_sim_results/electric_blue/test_aggregate_results.py
@@ -19,9 +19,11 @@ class TestForwardDeviceStats:
     @staticmethod
     def test_add_sell_trade(device_stats):
         trade1 = {
-            "seller_id": "UUID_1", "time_slot": "2020-01-01T00:00:00", "energy": 1, "price": 30}
+            "seller_id": "UUID_1", "time_slot": "2020-01-01T00:00:00",
+            "energy": 1, "price": 30, "energy_rate": 30}
         trade2 = {
-            "seller_id": "UUID_1", "time_slot": "2020-01-01T00:00:00", "energy": 1, "price": 40}
+            "seller_id": "UUID_1", "time_slot": "2020-01-01T00:00:00",
+            "energy": 1, "price": 40, "energy_rate": 40}
         device_stats.add_trade(trade1)
         device_stats.add_trade(trade2)
         result = {
@@ -36,6 +38,8 @@ class TestForwardDeviceStats:
             "total_buy_trade_count": 0,
             "total_energy_bought": 0,
             "total_spent_eur": 0,
+            "accumulated_buy_trade_rates": 0,
+            "accumulated_sell_trade_rates": 70
         }
         assert device_stats.to_dict() == result
 
@@ -45,9 +49,9 @@ class TestForwardDeviceStats:
     @staticmethod
     def test_add_buy_trade(device_stats):
         trade1 = {"buyer_id": "UUID_1", "seller_id": "UUID_2",
-                  "time_slot": "2020-01-01T00:00:00", "energy": 1, "price": 30}
+                  "time_slot": "2020-01-01T00:00:00", "energy": 1, "price": 30, "energy_rate": 30}
         trade2 = {"buyer_id": "UUID_1", "seller_id": "UUID_2",
-                  "time_slot": "2020-01-01T00:00:00", "energy": 1, "price": 40}
+                  "time_slot": "2020-01-01T00:00:00", "energy": 1, "price": 40, "energy_rate": 40}
         device_stats.add_trade(trade1)
         device_stats.add_trade(trade2)
         result = {
@@ -61,7 +65,9 @@ class TestForwardDeviceStats:
             "total_energy_consumed": 0,
             "total_buy_trade_count": 2,
             "total_energy_bought": 2,
-            "total_spent_eur": 70
+            "total_spent_eur": 70,
+            "accumulated_buy_trade_rates": 70,
+            "accumulated_sell_trade_rates": 0
         }
         assert device_stats.to_dict() == result
         assert device_stats.open_bids == []
@@ -70,13 +76,13 @@ class TestForwardDeviceStats:
     @staticmethod
     def test_add_buy_sell_trade(device_stats):
         trade1 = {"buyer_id": "UUID_1", "seller_id": "UUID_2",
-                  "time_slot": "2020-01-01T00:00:00", "energy": 1, "price": 30}
+                  "time_slot": "2020-01-01T00:00:00", "energy": 1, "price": 30, "energy_rate": 30}
         trade2 = {"buyer_id": "UUID_1", "seller_id": "UUID_2",
-                  "time_slot": "2020-01-01T00:00:00", "energy": 1, "price": 40}
+                  "time_slot": "2020-01-01T00:00:00", "energy": 1, "price": 40, "energy_rate": 40}
         trade3 = {"buyer_id": "UUID_2", "seller_id": "UUID_1",
-                  "time_slot": "2020-01-01T00:00:00", "energy": 2, "price": 40}
+                  "time_slot": "2020-01-01T00:00:00", "energy": 2, "price": 40, "energy_rate": 20}
         trade4 = {"buyer_id": "UUID_2", "seller_id": "UUID_1",
-                  "time_slot": "2020-01-01T00:00:00", "energy": 3, "price": 60}
+                  "time_slot": "2020-01-01T00:00:00", "energy": 3, "price": 60, "energy_rate": 20}
         device_stats.add_trade(trade1)
         device_stats.add_trade(trade2)
         device_stats.add_trade(trade3)
@@ -93,6 +99,8 @@ class TestForwardDeviceStats:
             "total_buy_trade_count": 2,
             "total_energy_bought": 2,
             "total_spent_eur": 70,
+            "accumulated_buy_trade_rates": 70,
+            "accumulated_sell_trade_rates": 40
         }
         assert device_stats.to_dict() == results
         assert device_stats.open_bids == []
@@ -130,6 +138,8 @@ class TestForwardDeviceStats:
             "total_buy_trade_count": 0,
             "total_energy_bought": 0,
             "total_spent_eur": 0,
+            "accumulated_sell_trade_rates": 0,
+            "accumulated_buy_trade_rates": 0
         }
         assert device_stats.to_dict() == result
         assert device_stats.open_bids == [
@@ -168,7 +178,9 @@ class TestForwardDeviceStats:
             "total_energy_consumed": 0,
             "total_buy_trade_count": 0,
             "total_energy_bought": 0,
-            "total_spent_eur": 0
+            "total_spent_eur": 0,
+            "accumulated_buy_trade_rates": 0,
+            "accumulated_sell_trade_rates": 0,
         }
         assert device_stats.to_dict() == result
         assert device_stats.open_bids == []
@@ -205,13 +217,15 @@ class TestForwardDeviceStats:
             "total_buy_trade_count": 1,
             "total_energy_bought": 1,
             "total_spent_eur": 30,
+            "accumulated_sell_trade_rates": 30,
+            "accumulated_buy_trade_rates": 30
         }
         global_device_stats = ForwardDeviceStats(**global_device_stats_dict)
 
         trade2 = {"seller_id": "UUID_1", "time_slot": "2020-01-01T00:00:00",
-                  "energy": 1, "price": 40}
+                  "energy": 1, "price": 40, "energy_rate": 40}
         trade4 = {"buyer_id": "UUID_1", "seller_id": "UUID_2",
-                  "time_slot": "2020-01-01T00:00:00", "energy": 1, "price": 40}
+                  "time_slot": "2020-01-01T00:00:00", "energy": 1, "price": 40, "energy_rate": 40}
         bid1 = {"buyer_id": "UUID_1", "price": 100, "energy": 2,
                 "time_slot": "2020-01-01T00:00:00"}
         offer1 = {"seller_id": "UUID_1", "price": 100, "energy": 2,
@@ -240,6 +254,7 @@ class TestForwardDeviceStats:
             "total_energy_sold": 2, "total_earned_eur": 70,
             "total_energy_consumed": 0, "total_buy_trade_count": 2,
             "total_energy_bought": 2, "total_spent_eur": 70,
+            "accumulated_buy_trade_rates": 70, "accumulated_sell_trade_rates": 70
         }
         assert new_global_device_stats.open_bids == [
             {"buyer_id": "UUID_1", "price": 100, "energy": 2, "time_slot": "2020-01-01T00:00:00"},
@@ -287,14 +302,14 @@ class TestForwardResultsHandler:
                 "offers": [{"seller_id": "UUID_1", "time_slot": "2020-02-01T00:00:00"}],
                 "trades": [{
                     "seller_id": "UUID_1", "buyer_id": "UUID_2", "energy": 1,
-                    "price": 30, "time_slot": "2020-02-01T00:00:00"}]
+                    "price": 30, "time_slot": "2020-02-01T00:00:00", "energy_rate": 30}]
             },
             "2020-03-01T00:00:00": {
                 "bids": [{"buyer_id": "UUID_4", "time_slot": "2020-03-01T00:00:00"}],
                 "offers": [{"seller_id": "UUID_3", "time_slot": "2020-03-01T00:00:00"}],
                 "trades": [{
                     "seller_id": "UUID_3", "buyer_id": "UUID_4", "energy": 2,
-                    "price": 40, "time_slot": "2020-03-01T00:00:00"}]
+                    "price": 40, "time_slot": "2020-03-01T00:00:00", "energy_rate": 20}]
             },
         }
         result = dict(handle_forward_results(current_time_slot, market_stats))
@@ -310,6 +325,7 @@ class TestForwardResultsHandler:
                     "total_energy_produced": 0, "total_sell_trade_count": 1,
                     "total_energy_sold": 1, "total_earned_eur": 30, "total_energy_consumed": 0,
                     "total_buy_trade_count": 0, "total_energy_bought": 0, "total_spent_eur": 0,
+                    "accumulated_buy_trade_rates": 0, "accumulated_sell_trade_rates": 30
                 },
                 "UUID_2": {
                     "time_slot": DateTime(2020, 2, 1, 0, 0, tzinfo=UTC), "device_uuid": "UUID_2",
@@ -317,6 +333,7 @@ class TestForwardResultsHandler:
                     "total_energy_produced": 0, "total_sell_trade_count": 0,
                     "total_energy_sold": 0, "total_earned_eur": 0, "total_energy_consumed": 0,
                     "total_buy_trade_count": 1, "total_energy_bought": 1, "total_spent_eur": 30,
+                    "accumulated_buy_trade_rates": 30, "accumulated_sell_trade_rates": 0
                 }
             },
             DateTime(2020, 3, 1, 0, 0, tzinfo=UTC): {
@@ -326,6 +343,7 @@ class TestForwardResultsHandler:
                     "total_energy_produced": 0, "total_sell_trade_count": 1,
                     "total_energy_sold": 2, "total_earned_eur": 40, "total_energy_consumed": 0,
                     "total_buy_trade_count": 0, "total_energy_bought": 0, "total_spent_eur": 0,
+                    "accumulated_buy_trade_rates": 0, "accumulated_sell_trade_rates": 20
                 },
                 "UUID_4": {
                     "time_slot": DateTime(2020, 3, 1, 0, 0, tzinfo=UTC), "device_uuid": "UUID_4",
@@ -333,6 +351,7 @@ class TestForwardResultsHandler:
                     "total_energy_produced": 0, "total_sell_trade_count": 0,
                     "total_energy_sold": 0, "total_earned_eur": 0, "total_energy_consumed": 0,
                     "total_buy_trade_count": 1, "total_energy_bought": 2, "total_spent_eur": 40,
+                    "accumulated_buy_trade_rates": 20, "accumulated_sell_trade_rates": 0
                 }
             },
         }

--- a/tests/test_sim_results/electric_blue/test_time_series.py
+++ b/tests/test_sim_results/electric_blue/test_time_series.py
@@ -20,10 +20,10 @@ def device_stats_fixture():
     )
     device_stats.add_trade({
         "seller_id": "UUID_1", "time_slot": "2020-01-01T00:00:00",
-        "energy": 1, "price": 30})
+        "energy": 1, "price": 30, "energy_rate": 30})
     device_stats.add_trade({
         "seller_id": "UUID_2", "buyer_id": "UUID_1",
-        "time_slot": "2020-01-01T00:00:00", "energy": 2, "price": 30})
+        "time_slot": "2020-01-01T00:00:00", "energy": 2, "price": 30, "energy_rate": 15})
     device_stats.add_offer({
         "seller_id": "UUID_1", "time_slot": "2020-01-01T00:00:00",
         "energy": 3, "price": 30})

--- a/tests/test_sim_results/electric_blue/test_volume_timeseries.py
+++ b/tests/test_sim_results/electric_blue/test_volume_timeseries.py
@@ -177,7 +177,7 @@ class TestAssetVolumeTimeSeries:
                 add_to_volume_time_series_mock.assert_has_calls(expected_calls)
 
     @staticmethod
-    def test__add_to_volume_time_series_works_correctly():
+    def test_add_to_volume_time_series_works_correctly():
         volume_time_series = AssetVolumeTimeSeries(
             asset_uuid="UUID", asset_peak_kWh=5, resolution=AggregationResolution.RES_1_MONTH)
         time_slot = DateTime(2020, 1, 1)

--- a/tests/test_sim_results/electric_blue/test_volume_timeseries.py
+++ b/tests/test_sim_results/electric_blue/test_volume_timeseries.py
@@ -1,15 +1,14 @@
 from typing import List
+from unittest.mock import Mock, call, patch
 
 import pytest
 from pendulum import DateTime
 
-from gsy_framework.enums import AggregationResolution
+from gsy_framework.enums import AggregationResolution, AvailableMarketTypes
 from gsy_framework.sim_results.electric_blue.aggregate_results import (
     ForwardDeviceStats)
 from gsy_framework.sim_results.electric_blue.volume_timeseries import (
     FORWARD_PRODUCT_TYPES, AssetVolumeTimeSeries)
-from tests.forward_markets.test_aggregated_profile import (
-    get_sum_of_ssp_profile_range_values as sum_of_energy)
 
 
 @pytest.fixture
@@ -22,7 +21,10 @@ def forward_time_series():
                 time_slot=DateTime(2020, 1, 1),
                 current_time_slot=DateTime(2020, 1, 1),
                 total_energy_sold=1,
-                total_energy_bought=1)
+                total_energy_bought=1,
+                total_spent_eur=30,
+                total_earned_eur=45
+            )
     return func()
 
 
@@ -76,79 +78,128 @@ class TestAssetVolumeTimeSeries:
             (DateTime(2020, 2, 29, 0, 20).start_of("year"), DateTime(2020, 2, 29, 0, 20)),
         ], resolution=AggregationResolution.RES_1_YEAR)
 
-    def test_add_asset_time_series_for_1_year_resolution(self, forward_time_series):
+    @patch.object(AssetVolumeTimeSeries, "_add_total_energy_bought")
+    @patch.object(AssetVolumeTimeSeries, "_add_total_energy_sold")
+    def test_update_time_series_method_works(
+            self, add_total_energy_bought_mock, add_total_energy_sold_mock):
         volume_time_series = AssetVolumeTimeSeries(
             asset_uuid="UUID", asset_peak_kWh=5, resolution=AggregationResolution.RES_1_YEAR)
 
-        for product_type, asset_stats in forward_time_series:
-            volume_time_series.update_time_series(asset_stats, product_type)
+        asset_stats = ForwardDeviceStats("UUID", DateTime(2020, 1, 1), DateTime(2020, 1, 1))
+        volume_time_series.update_time_series(asset_stats, AvailableMarketTypes.WEEK_FORWARD)
 
         self.check_time_slots_year(volume_time_series)
-        assert volume_time_series._asset_time_series_buffer == {
-            DateTime(2020, 1, 1, 0, 0, 0): {
-                str(DateTime(2020, 1, 1, 0, 0, 0)): {
-                    "SSP": 36164.701938689024,
-                    "YEAR_FORWARD": {
-                        "bought_kWh": sum_of_energy(
-                            DateTime(2020, 1, 1, 0, 0, 0),
-                            DateTime(2020, 1, 1, 0, 0, 0).end_of("year"),
-                            1
-                        ),
-                        "sold_kWh": sum_of_energy(
-                            DateTime(2020, 1, 1, 0, 0, 0),
-                            DateTime(2020, 1, 1, 0, 0, 0).end_of("year"),
-                            1
-                        )},
-                    "MONTH_FORWARD": {
-                        "bought_kWh": sum_of_energy(
-                            DateTime(2020, 1, 1, 0, 0, 0),
-                            DateTime(2020, 1, 1, 0, 0, 0).end_of("month"),
-                            1
-                        ),
-                        "sold_kWh": sum_of_energy(
-                            DateTime(2020, 1, 1, 0, 0, 0),
-                            DateTime(2020, 1, 1, 0, 0, 0).end_of("month"),
-                            1
+        add_total_energy_bought_mock.assert_called_once()
+        add_total_energy_sold_mock.assert_called_once()
+
+    @staticmethod
+    def test_add_total_energy_bought_works_correctly():
+        volume_time_series = AssetVolumeTimeSeries(
+            asset_uuid="UUID", asset_peak_kWh=5, resolution=AggregationResolution.RES_1_WEEK)
+
+        profile = {f"time_slot_{i}": 0.5 for i in range(3)}
+        with patch.object(
+                volume_time_series._trade_profile_generator,
+                "generate_trade_profile", Mock(return_value=profile)) as profile_generator_mock:
+            # profile generator should not be called when total_energy_bought is <= 0
+            asset_stats = ForwardDeviceStats("UUID", DateTime(2020, 1, 1), DateTime(2020, 1, 1))
+            volume_time_series._add_total_energy_bought(
+                asset_stats, AvailableMarketTypes.YEAR_FORWARD)
+            profile_generator_mock.assert_not_called()
+
+            # profile generator should be called when total_energy_bought is > 0
+            with patch.object(
+                volume_time_series, "_add_to_volume_time_series"
+            ) as add_to_volume_time_series_mock:
+                asset_stats = ForwardDeviceStats(
+                    "UUID", DateTime(2020, 1, 1), DateTime(2020, 1, 1), total_energy_bought=2,
+                    total_spent_eur=0.6)
+                volume_time_series._add_total_energy_bought(
+                    asset_stats, AvailableMarketTypes.YEAR_FORWARD)
+                profile_generator_mock.assert_called_once_with(
+                    asset_stats.total_energy_bought, asset_stats.time_slot,
+                    AvailableMarketTypes.YEAR_FORWARD
+                )
+                expected_calls = []
+                for time_slot, energy in profile.items():
+                    expected_calls.append(
+                        call.do_work(
+                            time_slot,
+                            {
+                                "energy_kWh": energy,
+                                "price": energy * asset_stats.average_buy_price},
+                            AvailableMarketTypes.YEAR_FORWARD, "bought"
                         )
-                    },
-                    "WEEK_FORWARD": {
-                        "bought_kWh": sum_of_energy(
-                            DateTime(2020, 1, 1, 0, 0, 0),
-                            DateTime(2020, 1, 1, 0, 0, 0).end_of("week"),
-                            1
-                        ),
-                        "sold_kWh": sum_of_energy(
-                            DateTime(2020, 1, 1, 0, 0, 0),
-                            DateTime(2020, 1, 1, 0, 0, 0).end_of("week"),
-                            1
-                        )},
-                    "DAY_FORWARD": {"bought_kWh": sum_of_energy(
-                            DateTime(2020, 1, 1, 0, 0, 0),
-                            DateTime(2020, 1, 1, 0, 0, 0).end_of("day"),
-                            1
-                        ), "sold_kWh": sum_of_energy(
-                            DateTime(2020, 1, 1, 0, 0, 0),
-                            DateTime(2020, 1, 1, 0, 0, 0).end_of("day"),
-                            1
-                        )}}},
-            DateTime(2019, 1, 1, 0, 0, 0): {
-                str(DateTime(2019, 1, 1, 0, 0, 0)): {
-                    "SSP": 36100.3496802018,
-                    "YEAR_FORWARD": {"bought_kWh": 0, "sold_kWh": 0},
-                    "MONTH_FORWARD": {"bought_kWh": 0, "sold_kWh": 0},
-                    "WEEK_FORWARD": {
-                        "bought_kWh": sum_of_energy(
-                            DateTime(2020, 1, 1, 0, 0, 0).start_of("week"),
-                            DateTime(2020, 1, 1, 0, 0, 0),
-                            1
-                        ),
-                        "sold_kWh": sum_of_energy(
-                            DateTime(2020, 1, 1, 0, 0, 0).start_of("week"),
-                            DateTime(2020, 1, 1, 0, 0, 0),
-                            1
+                    )
+                assert add_to_volume_time_series_mock.call_count == 3
+                add_to_volume_time_series_mock.assert_has_calls(expected_calls)
+
+    @staticmethod
+    def test_add_total_energy_sold_works_correctly():
+        volume_time_series = AssetVolumeTimeSeries(
+            asset_uuid="UUID", asset_peak_kWh=5, resolution=AggregationResolution.RES_1_WEEK)
+
+        profile = {f"time_slot_{i}": 0.5 for i in range(3)}
+        with patch.object(
+                volume_time_series._trade_profile_generator,
+                "generate_trade_profile", Mock(return_value=profile)) as profile_generator_mock:
+            # profile generator should not be called when total_energy_bought is <= 0
+            asset_stats = ForwardDeviceStats("UUID", DateTime(2020, 1, 1), DateTime(2020, 1, 1))
+            volume_time_series._add_total_energy_sold(
+                asset_stats, AvailableMarketTypes.YEAR_FORWARD)
+            profile_generator_mock.assert_not_called()
+
+            # profile generator should be called when total_energy_bought is > 0
+            with patch.object(
+                volume_time_series, "_add_to_volume_time_series"
+            ) as add_to_volume_time_series_mock:
+                asset_stats = ForwardDeviceStats(
+                    "UUID", DateTime(2020, 1, 1), DateTime(2020, 1, 1), total_energy_sold=2,
+                    total_earned_eur=0.6)
+                volume_time_series._add_total_energy_sold(
+                    asset_stats, AvailableMarketTypes.YEAR_FORWARD)
+                profile_generator_mock.assert_called_once_with(
+                    asset_stats.total_energy_sold, asset_stats.time_slot,
+                    AvailableMarketTypes.YEAR_FORWARD
+                )
+                expected_calls = []
+                for time_slot, energy in profile.items():
+                    expected_calls.append(
+                        call.do_work(
+                            time_slot,
+                            {
+                                "energy_kWh": energy,
+                                "price": energy * asset_stats.average_sell_price},
+                            AvailableMarketTypes.YEAR_FORWARD, "sold"
                         )
-                    },
-                    "DAY_FORWARD": {"bought_kWh": 0, "sold_kWh": 0}}}}
+                    )
+                assert add_to_volume_time_series_mock.call_count == 3
+                add_to_volume_time_series_mock.assert_has_calls(expected_calls)
+
+    @staticmethod
+    def test__add_to_volume_time_series_works_correctly():
+        volume_time_series = AssetVolumeTimeSeries(
+            asset_uuid="UUID", asset_peak_kWh=5, resolution=AggregationResolution.RES_1_MONTH)
+        time_slot = DateTime(2020, 1, 1)
+        time_slot_info = {
+            "energy_kWh": 1,
+            "price": 0.0
+        }
+        volume_time_series._add_to_volume_time_series(
+            time_slot, time_slot_info, AvailableMarketTypes.MONTH_FORWARD, "sold")
+        sold_time_slot_data = volume_time_series._asset_time_series_buffer[time_slot.start_of(
+            "year")][str(time_slot)]["MONTH_FORWARD"]["sold"]
+        assert sold_time_slot_data == {"energy_kWh": 1.0, "price": 0.0, "energy_rate": 0.0}
+
+        time_slot_info = {
+            "energy_kWh": 1,
+            "price": 0.6
+        }
+        volume_time_series._add_to_volume_time_series(
+            time_slot, time_slot_info, AvailableMarketTypes.MONTH_FORWARD, "sold")
+        sold_time_slot_data = volume_time_series._asset_time_series_buffer[time_slot.start_of(
+            "year")][str(time_slot)]["MONTH_FORWARD"]["sold"]
+        assert sold_time_slot_data == {"energy_kWh": 2.0, "price": 0.6, "energy_rate": 0.3}
 
     def test_add_asset_time_series_for_1_month_resolution(self, forward_time_series):
         """Call AssetVolumeTimeSeries in 1-month resolution to assure no KeyErrors happen."""

--- a/tests/test_sim_results/electric_blue/test_volume_timeseries.py
+++ b/tests/test_sim_results/electric_blue/test_volume_timeseries.py
@@ -127,7 +127,9 @@ class TestAssetVolumeTimeSeries:
                             time_slot,
                             {
                                 "energy_kWh": energy,
-                                "price": energy * asset_stats.average_buy_rate},
+                                "trade_count": asset_stats.total_buy_trade_count,
+                                "accumulated_trade_rates": asset_stats.accumulated_buy_trade_rates
+                            },
                             AvailableMarketTypes.YEAR_FORWARD, "bought"
                         )
                     )
@@ -169,7 +171,9 @@ class TestAssetVolumeTimeSeries:
                             time_slot,
                             {
                                 "energy_kWh": energy,
-                                "price": energy * asset_stats.average_sell_rate},
+                                "trade_count": asset_stats.total_sell_trade_count,
+                                "accumulated_trade_rates": asset_stats.accumulated_sell_trade_rates
+                            },
                             AvailableMarketTypes.YEAR_FORWARD, "sold"
                         )
                     )
@@ -183,23 +187,25 @@ class TestAssetVolumeTimeSeries:
         time_slot = DateTime(2020, 1, 1)
         time_slot_info = {
             "energy_kWh": 1,
-            "price": 0.0
+            "trade_count": 1,
+            "accumulated_trade_rates": 0.3
         }
         volume_time_series._add_to_volume_time_series(
             time_slot, time_slot_info, AvailableMarketTypes.MONTH_FORWARD, "sold")
         sold_time_slot_data = volume_time_series._asset_time_series_buffer[time_slot.start_of(
             "year")][str(time_slot)]["MONTH_FORWARD"]["sold"]
-        assert sold_time_slot_data == {"energy_kWh": 1.0, "price": 0.0, "energy_rate": 0.0}
+        assert sold_time_slot_data == {"energy_kWh": 1.0, "energy_rate": 0.3, "trade_count": 1}
 
         time_slot_info = {
             "energy_kWh": 1,
-            "price": 0.6
+            "trade_count": 2,
+            "accumulated_trade_rates": 0.4
         }
         volume_time_series._add_to_volume_time_series(
             time_slot, time_slot_info, AvailableMarketTypes.MONTH_FORWARD, "sold")
         sold_time_slot_data = volume_time_series._asset_time_series_buffer[time_slot.start_of(
             "year")][str(time_slot)]["MONTH_FORWARD"]["sold"]
-        assert sold_time_slot_data == {"energy_kWh": 2.0, "price": 0.6, "energy_rate": 0.3}
+        assert sold_time_slot_data == {"energy_kWh": 2.0, "energy_rate": 0.23, "trade_count": 3}
 
     def test_add_asset_time_series_for_1_month_resolution(self, forward_time_series):
         """Call AssetVolumeTimeSeries in 1-month resolution to assure no KeyErrors happen."""

--- a/tests/test_sim_results/electric_blue/test_volume_timeseries.py
+++ b/tests/test_sim_results/electric_blue/test_volume_timeseries.py
@@ -39,8 +39,8 @@ class TestAssetVolumeTimeSeries:
     @staticmethod
     def check_time_slots_year(volume_time_series: AssetVolumeTimeSeries):
         """Check all timeslots of a given year belong to that year."""
-        for year in volume_time_series._asset_volume_time_series_buffer:
-            for year_within in volume_time_series._asset_volume_time_series_buffer[year]:
+        for year in volume_time_series._asset_time_series_buffer:
+            for year_within in volume_time_series._asset_time_series_buffer[year]:
                 assert year_within.startswith(str(year.year))
 
     def test_adapt_time_slot_for_15_minute_resolution(self):
@@ -81,10 +81,10 @@ class TestAssetVolumeTimeSeries:
             asset_uuid="UUID", asset_peak_kWh=5, resolution=AggregationResolution.RES_1_YEAR)
 
         for product_type, asset_stats in forward_time_series:
-            volume_time_series.update_volume_time_series(asset_stats, product_type)
+            volume_time_series.update_time_series(asset_stats, product_type)
 
         self.check_time_slots_year(volume_time_series)
-        assert volume_time_series._asset_volume_time_series_buffer == {
+        assert volume_time_series._asset_time_series_buffer == {
             DateTime(2020, 1, 1, 0, 0, 0): {
                 str(DateTime(2020, 1, 1, 0, 0, 0)): {
                     "SSP": 36164.701938689024,
@@ -157,7 +157,7 @@ class TestAssetVolumeTimeSeries:
 
         try:
             for product_type, asset_stats in forward_time_series:
-                volume_time_series.update_volume_time_series(asset_stats, product_type)
+                volume_time_series.update_time_series(asset_stats, product_type)
         except KeyError as exc:
             pytest.fail(str(exc))
 
@@ -170,7 +170,7 @@ class TestAssetVolumeTimeSeries:
 
         try:
             for product_type, asset_stats in forward_time_series:
-                volume_time_series.update_volume_time_series(asset_stats, product_type)
+                volume_time_series.update_time_series(asset_stats, product_type)
         except KeyError as exc:
             pytest.fail(str(exc))
 
@@ -183,7 +183,7 @@ class TestAssetVolumeTimeSeries:
 
         try:
             for product_type, asset_stats in forward_time_series:
-                volume_time_series.update_volume_time_series(asset_stats, product_type)
+                volume_time_series.update_time_series(asset_stats, product_type)
         except KeyError as exc:
             pytest.fail(str(exc))
 
@@ -196,7 +196,7 @@ class TestAssetVolumeTimeSeries:
 
         try:
             for product_type, asset_stats in forward_time_series:
-                volume_time_series.update_volume_time_series(asset_stats, product_type)
+                volume_time_series.update_time_series(asset_stats, product_type)
         except KeyError as exc:
             pytest.fail(str(exc))
 

--- a/tests/test_sim_results/electric_blue/test_volume_timeseries.py
+++ b/tests/test_sim_results/electric_blue/test_volume_timeseries.py
@@ -127,7 +127,7 @@ class TestAssetVolumeTimeSeries:
                             time_slot,
                             {
                                 "energy_kWh": energy,
-                                "price": energy * asset_stats.average_buy_price},
+                                "price": energy * asset_stats.average_buy_rate},
                             AvailableMarketTypes.YEAR_FORWARD, "bought"
                         )
                     )
@@ -169,7 +169,7 @@ class TestAssetVolumeTimeSeries:
                             time_slot,
                             {
                                 "energy_kWh": energy,
-                                "price": energy * asset_stats.average_sell_price},
+                                "price": energy * asset_stats.average_sell_rate},
                             AvailableMarketTypes.YEAR_FORWARD, "sold"
                         )
                     )

--- a/tests/test_sim_results/electric_blue/test_volume_timeseries.py
+++ b/tests/test_sim_results/electric_blue/test_volume_timeseries.py
@@ -194,7 +194,9 @@ class TestAssetVolumeTimeSeries:
             time_slot, time_slot_info, AvailableMarketTypes.MONTH_FORWARD, "sold")
         sold_time_slot_data = volume_time_series._asset_time_series_buffer[time_slot.start_of(
             "year")][str(time_slot)]["MONTH_FORWARD"]["sold"]
-        assert sold_time_slot_data == {"energy_kWh": 1.0, "energy_rate": 0.3, "trade_count": 1}
+        assert sold_time_slot_data == {
+            "energy_kWh": 1.0, "energy_rate": 0.3,
+            "trade_count": 1, "accumulated_trade_rates": 0.3}
 
         time_slot_info = {
             "energy_kWh": 1,
@@ -205,7 +207,9 @@ class TestAssetVolumeTimeSeries:
             time_slot, time_slot_info, AvailableMarketTypes.MONTH_FORWARD, "sold")
         sold_time_slot_data = volume_time_series._asset_time_series_buffer[time_slot.start_of(
             "year")][str(time_slot)]["MONTH_FORWARD"]["sold"]
-        assert sold_time_slot_data == {"energy_kWh": 2.0, "energy_rate": 0.23, "trade_count": 3}
+        assert sold_time_slot_data == {
+            "energy_kWh": 2.0, "energy_rate": 0.23,
+            "trade_count": 3, "accumulated_trade_rates": 0.7}
 
     def test_add_asset_time_series_for_1_month_resolution(self, forward_time_series):
         """Call AssetVolumeTimeSeries in 1-month resolution to assure no KeyErrors happen."""


### PR DESCRIPTION
### Please review commit by commit. Thanks

As requested by [GSYE-414](https://gridsingularity.atlassian.net/browse/GSYE-414), we need to pre-calculate price profile in different resolutions for each asset.

Proposed changes:
- Refactor AssetVolumeTimeSeries into two classes (AssetVolumeTimeSeries & AssetTimeSeriesBase)
- Add price and energy_rate calculation to AssetVolumeTimeSeries
- Major refactor for unit tests

![Screenshot from 2022-10-18 13-04-07](https://user-images.githubusercontent.com/31365000/196953366-b97e2dd9-2dbe-470c-93d7-d22db523616e.png)
