### PR TITLE
GSYE-445: Replace MarketEnergyBills with SCMBills for SCM simulations

### DIFF
--- a/gsy_framework/sim_results/all_results.py
+++ b/gsy_framework/sim_results/all_results.py
@@ -4,19 +4,20 @@ from typing import Dict
 
 from gsy_framework.sim_results.area_throughput_stats import AreaThroughputStats
 from gsy_framework.sim_results.bills import CumulativeBills, MarketEnergyBills
-from gsy_framework.sim_results.cumulative_grid_trades import \
-    CumulativeGridTrades
-from gsy_framework.sim_results.cumulative_net_energy_flow import \
-    CumulativeNetEnergyFlow
+from gsy_framework.sim_results.cumulative_grid_trades import (
+    CumulativeGridTrades)
+from gsy_framework.sim_results.cumulative_net_energy_flow import (
+    CumulativeNetEnergyFlow)
 from gsy_framework.sim_results.device_statistics import DeviceStatistics
 from gsy_framework.sim_results.energy_trade_profile import EnergyTradeProfile
 from gsy_framework.sim_results.kpi import KPI
-from gsy_framework.sim_results.market_price_energy_day import \
-    MarketPriceEnergyDay
+from gsy_framework.sim_results.market_price_energy_day import (
+    MarketPriceEnergyDay)
 from gsy_framework.sim_results.market_summary_info import MarketSummaryInfo
+from gsy_framework.sim_results.scm.bills import SCMBills
 from gsy_framework.sim_results.scm.kpi import SCMKPI
-from gsy_framework.sim_results.simulation_assets_info import \
-    SimulationAssetsInfo
+from gsy_framework.sim_results.simulation_assets_info import (
+    SimulationAssetsInfo)
 
 
 class ResultsHandler:
@@ -40,7 +41,7 @@ class ResultsHandler:
         }
 
         if is_scm:
-            self.results_mapping["bills"] = MarketEnergyBills(should_export_plots)
+            self.results_mapping["bills"] = SCMBills()
             self.results_mapping["kpi"] = SCMKPI()
         else:
             self.results_mapping["bills"] = MarketEnergyBills(should_export_plots)


### PR DESCRIPTION
As requested by [GSYE-445](https://gridsingularity.atlassian.net/browse/GSYE-445), we want to replace MarketEnergyBills with SCMBills for SCM simulations.

Old SCM bills format (for each area):
![old_format](https://user-images.githubusercontent.com/31365000/203040915-7488f095-b22b-42ac-8f9a-b97bd3518ef1.png)

New SCM bills format (for each area):
![new_format](https://user-images.githubusercontent.com/31365000/203040988-de8d1735-0879-4adf-8350-b0e992f65e26.png)
