### PR TITLE
Used 0 values in the accumulation of SCM energy bills if None values …

### DIFF
--- a/gsy_framework/sim_results/scm/bills.py
+++ b/gsy_framework/sim_results/scm/bills.py
@@ -61,7 +61,7 @@ class SCMBills(ResultsBaseClass):
                 self.bills_redis_results[area["uuid"]] = self._empty_bills_dict()
 
             area_bills = {
-                k: v + core_stats[area["uuid"]]["bills"].get(k, 0.)
+                k: (v or 0.) + (core_stats[area["uuid"]]["bills"].get(k, 0.) or 0.)
                 for k, v in self.bills_redis_results[area["uuid"]].items()
             }
 


### PR DESCRIPTION
…are sent by gsy-e.

This is a fix for the following error on dev env:

```
ERROR 2023-01-03 08:02:33,765 redis_results_subscription 1 139838343550784 Simulation results handling for job id 213e8ecd-f3b5-4766-bc61-2e3ad87e769b failed with an error: unsupported operand type(s) for +: 'NoneType' and 'float'
Traceback (most recent call last):
  File "/app/simulation_results/redis_results_subscription.py", line 55, in _simulation_results_handler
    self.results_calculation.update_simulation_result(message)
  File "/app/simulation_results/results_calculation_helper.py", line 61, in update_simulation_result
    self._calculate_current_market_sim_results(data)
  File "/app/simulation_results/results_calculation_helper.py", line 114, in _calculate_current_market_sim_results
    self.simulation_results[data["job_id"]].update(config_tree, core_stats, current_market_ts)
  File "/usr/local/lib/python3.8/site-packages/gsy_framework/sim_results/all_results.py", line 80, in update
    result_object.update(area_dict, core_stats, current_market_slot)
  File "/usr/local/lib/python3.8/site-packages/gsy_framework/sim_results/scm/bills.py", line 63, in update
    area_bills = {
  File "/usr/local/lib/python3.8/site-packages/gsy_framework/sim_results/scm/bills.py", line 64, in <dictcomp>
    k: v + core_stats[area["uuid"]]["bills"].get(k, 0.)
TypeError: unsupported operand type(s) for +: 'NoneType' and 'float'
```