### PR TITLE
Fix is_offer_trade and is_bid_trade

### DIFF
--- a/gsy_framework/data_classes.py
+++ b/gsy_framework/data_classes.py
@@ -405,12 +405,14 @@ class Trade:
     @property
     def is_bid_trade(self) -> bool:
         """Check if the instance is a bid trade."""
-        return self.match_details["bid"] is not None
+        return (self.offer_bid_trade_info.original_bid_rate is not None
+                if self.offer_bid_trade_info else False)
 
     @property
     def is_offer_trade(self) -> bool:
         """Check if the instance is an offer trade."""
-        return self.match_details["offer"] is not None
+        return (self.offer_bid_trade_info.original_offer_rate is not None
+                if self.offer_bid_trade_info else False)
 
     @property
     def trade_rate(self):

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -526,6 +526,12 @@ class TestTrade:
             "buyer": self._buyer,
             "traded_energy": 1,
             "trade_price": 1,
+            "offer_bid_trade_info": TradeBidOfferInfo(
+                original_bid_rate=None,
+                propagated_bid_rate=None,
+                original_offer_rate=1,
+                propagated_offer_rate=2,
+                trade_rate=1),
             "matching_requirements": {"requirement": "value"}}
 
     def test_str(self):
@@ -583,8 +589,12 @@ class TestTrade:
         )
         assert trade.is_bid_trade is False
 
-        trade.match_details["bid"] = Bid("id", DateTime.now(), 1, 2, self._buyer)
-        trade.match_details["offer"] = None
+        trade.offer_bid_trade_info = TradeBidOfferInfo(
+            original_bid_rate=1,
+            propagated_bid_rate=2,
+            original_offer_rate=None,
+            propagated_offer_rate=None,
+            trade_rate=1)
         assert trade.is_bid_trade is True
 
     def test_is_offer_trade(self):
@@ -593,8 +603,12 @@ class TestTrade:
         )
         assert trade.is_offer_trade is True
 
-        trade.match_details["bid"] = Bid("id", DateTime.now(), 1, 2, self._buyer)
-        trade.match_details["offer"] = None
+        trade.offer_bid_trade_info = TradeBidOfferInfo(
+            original_bid_rate=1,
+            propagated_bid_rate=2,
+            original_offer_rate=None,
+            propagated_offer_rate=None,
+            trade_rate=1)
         assert trade.is_offer_trade is False
 
     def test_serializable_dict(self):


### PR DESCRIPTION
As the bid and offer objects are always passed tot he Trade object, we can not decide if `is_bid_trade` or `is_offer_trade` from that. I propose to use the `offer_bid_trade_info` member for this decisions.