### PR TITLE
Added market maker state in the AVRO schema, in order to differentiat…

### DIFF
--- a/gsy_framework/schema/avro_schemas/simulation_state.json
+++ b/gsy_framework/schema/avro_schemas/simulation_state.json
@@ -175,6 +175,26 @@
           ]
         },
         {
+          "name": "MarketMakerStats",
+          "type": "record",
+          "fields": [
+            {
+              "name": "current_tick",
+              "type": [
+                "null",
+                "int"
+              ]
+            },
+            {
+              "name": "energy_rate",
+              "type": {
+                "type": "map",
+                "values": "float"
+              }
+            }
+          ]
+        },
+        {
           "name": "PVAreaStats",
           "type": "record",
           "fields": [


### PR DESCRIPTION
…e from the infinite bus state.