### PR TITLE
Reverted the clause that controls whether the profile is copied in mu…

### DIFF
--- a/gsy_framework/read_user_profile.py
+++ b/gsy_framework/read_user_profile.py
@@ -331,9 +331,10 @@ def read_arbitrary_profile(profile_type: InputProfileTypes,
     profile_time_list = list(profile.keys())
     profile_duration = profile_time_list[-1] - profile_time_list[0]
     if ((GlobalConfig.sim_duration > duration(days=1) and
-         GlobalConfig.sim_duration > profile_duration) or
+         profile_duration == duration(days=1)) or
             GlobalConfig.is_canary_network()):
         profile = _copy_profile_to_multiple_days(profile, current_timestamp=current_timestamp)
+
     if profile is not None:
         if profile_type is not InputProfileTypes.ENERGY_KWH:
             zero_value_slot_profile = default_profile_dict(current_timestamp=current_timestamp)


### PR DESCRIPTION
…ltiple days, and specified it even more in order to apply only in case the profile is exactly a daily one. If not, the profile should not be used in order to be copied to more days.

Root cause of the issue was this method `_copy_profile_to_multiple_days`. If this method is called with a daily profile, then the first/single day is used in order to copy to following days. If the method is called with a weekly profile though, it will use the last day of the profile, and overwrite the existing profile in order to all be copies of the last day of the profile. 
As a hotfix, corrected the clause in order for this method to get called only if the input is a daily profile and not a multi-day profile. 