### PR TITLE
Corrected AVRO schema for LoadHours strategy. Fixed simulation result…

### DIFF
--- a/gsy_framework/schema/avro_schemas/launch_simulation_scenario.json
+++ b/gsy_framework/schema/avro_schemas/launch_simulation_scenario.json
@@ -258,12 +258,10 @@
                   }
                 ]},
                 {"name": "avg_power_W", "type": ["null", "float"]},
-                {"name": "capacity_kW", "type": ["null", "float"]},
                 {"name": "final_buying_rate", "type": ["null", "float"]},
                 {"name": "initial_buying_rate", "type": ["null", "float"]},
                 {"name": "target_device_kpi", "type": ["null", "int"]},
                 {"name": "use_market_maker_rate", "type": ["null", "boolean"]},
-                {"name": "forecast_stream_enabled", "type": ["null", "boolean"]},
                 {"name": "allow_external_connection", "type": ["null", "boolean"]},
                 {"name": "energy_rate_increase_per_update", "type": ["null", "float"]},
                 {"name":  "display_type", "type":  "string"}

--- a/gsy_framework/sim_results/electric_blue/all_results.py
+++ b/gsy_framework/sim_results/electric_blue/all_results.py
@@ -147,9 +147,11 @@ class ForwardResultsHandler:  # pylint: disable=too-many-instance-attributes
 
         asset_uuid = current_asset_stats.device_uuid
         if asset_uuid not in self.asset_volume_time_series:
+            # We assume that for EB, slot length is 1 hour, hence no need for conversion between
+            # power and energy
             asset_peak_kwh = (
                 asset_info["capacity_kW"] if "capacity_kW" in asset_info
-                else asset_info["avg_power_W"])
+                else asset_info["avg_power_W"] * 1000.0)
             self.asset_volume_time_series[asset_uuid] = {
                 resolution: AssetVolumeTimeSeries(
                     asset_uuid=asset_uuid,

--- a/gsy_framework/sim_results/electric_blue/all_results.py
+++ b/gsy_framework/sim_results/electric_blue/all_results.py
@@ -147,10 +147,13 @@ class ForwardResultsHandler:  # pylint: disable=too-many-instance-attributes
 
         asset_uuid = current_asset_stats.device_uuid
         if asset_uuid not in self.asset_volume_time_series:
+            asset_peak_kwh = (
+                asset_info["capacity_kW"] if "capacity_kW" in asset_info
+                else asset_info["avg_power_W"])
             self.asset_volume_time_series[asset_uuid] = {
                 resolution: AssetVolumeTimeSeries(
                     asset_uuid=asset_uuid,
-                    asset_peak_kWh=asset_info["capacity_kW"],
+                    asset_peak_kWh=asset_peak_kwh,
                     resolution=resolution,
                     get_asset_volume_time_series_db=self.get_asset_volume_time_series_db,
                 ) for resolution in list(AggregationResolution)}

--- a/tests/schema/test_scenario_validator.py
+++ b/tests/schema/test_scenario_validator.py
@@ -180,7 +180,6 @@ class TestScenarioValidator:
                   "uuid": "cd3a108a-4eac-4f58-8d3a-e4f395a0aea4",
                   "address": None,
                   "avg_power_W": 100,
-                  "capacity_kW": None,
                   "libraryUUID": None,
                   "fit_to_limit": True,
                   "update_interval": 1,
@@ -192,7 +191,6 @@ class TestScenarioValidator:
                   "target_device_kpi": 0,
                   "initial_buying_rate": 0.0,
                   "use_market_maker_rate": True,
-                  "forecast_stream_enabled": None,
                   "allow_external_connection": False,
                   "energy_rate_increase_per_update": None,
                   "display_type": "Load"
@@ -209,7 +207,6 @@ class TestScenarioValidator:
                       "uuid": "1bb73f37-1ea9-4e6e-95bf-f053cd66dd45",
                       "address": None,
                       "avg_power_W": 100,
-                      "capacity_kW": None,
                       "libraryUUID": None,
                       "fit_to_limit": True,
                       "update_interval": 1,
@@ -221,7 +218,6 @@ class TestScenarioValidator:
                       "target_device_kpi": 0,
                       "initial_buying_rate": 0.0,
                       "use_market_maker_rate": True,
-                      "forecast_stream_enabled": None,
                       "allow_external_connection": False,
                       "energy_rate_increase_per_update": None,
                       "display_type": "Load"


### PR DESCRIPTION
…s for Electric Blue to use avg_power_W and not the capacity_kW argument for load strategies.