### PR TITLE
Add early return in the read_arbitrary_profile, to not parse empty pr…

### DIFF
--- a/gsy_framework/constants_limits.py
+++ b/gsy_framework/constants_limits.py
@@ -297,6 +297,7 @@ class GlobalConfig:
     POWER_FLOW = False
     FEED_IN_TARIFF = 0
     CONFIG_TYPE = ConfigurationType.SIMULATION.value
+    RUN_IN_REALTIME = False
 
     # Default simulation settings gsy-e side:
     start_date = instance((datetime.combine(START_DATE, datetime.min.time())))

--- a/gsy_framework/read_user_profile.py
+++ b/gsy_framework/read_user_profile.py
@@ -386,32 +386,30 @@ def read_arbitrary_profile(
         profile = _copy_profile_to_multiple_days(profile, current_timestamp=current_timestamp)
 
     logger.error(f"After _copy_profile_to_multiple_days {profile}")
-    if profile is not None:
-        try:
-            if profile_type is InputProfileTypes.ENERGY_KWH:
-                profile = {
-                    ts: convert_kWh_to_W(energy, GlobalConfig.slot_length)
-                    for ts, energy in profile.items()
-                }
-            if profile_type is InputProfileTypes.CARBON_RATIO_G_KWH:
-                return profile
-            zero_value_slot_profile = default_profile_dict(current_timestamp=current_timestamp)
-            filled_profile = _fill_gaps_in_profile(profile, zero_value_slot_profile)
-            if profile_type in [
-                InputProfileTypes.POWER_W,
-                InputProfileTypes.REBASE_W,
-                InputProfileTypes.ENERGY_KWH,
-            ]:
-                return _calculate_energy_from_power_profile(
-                    filled_profile, GlobalConfig.slot_length
-                )
-            return filled_profile
-        except IndexError as exc:
-            logger.error("Profile failed: %s", profile)
-            raise GSyReadProfileException(
-                "Filling gaps and converting profile failed: %s", input_profile
-            ) from exc
-    return None
+    if not profile:
+        return None
+    try:
+        if profile_type is InputProfileTypes.ENERGY_KWH:
+            profile = {
+                ts: convert_kWh_to_W(energy, GlobalConfig.slot_length)
+                for ts, energy in profile.items()
+            }
+        if profile_type is InputProfileTypes.CARBON_RATIO_G_KWH:
+            return profile
+        zero_value_slot_profile = default_profile_dict(current_timestamp=current_timestamp)
+        filled_profile = _fill_gaps_in_profile(profile, zero_value_slot_profile)
+        if profile_type in [
+            InputProfileTypes.POWER_W,
+            InputProfileTypes.REBASE_W,
+            InputProfileTypes.ENERGY_KWH,
+        ]:
+            return _calculate_energy_from_power_profile(filled_profile, GlobalConfig.slot_length)
+        return filled_profile
+    except IndexError as exc:
+        logger.error("Profile failed: %s", profile)
+        raise GSyReadProfileException(
+            "Filling gaps and converting profile failed: %s", input_profile
+        ) from exc
 
 
 def _generate_slot_based_zero_values_dict_from_profile(profile, slot_length_mins=15):

--- a/gsy_framework/utils.py
+++ b/gsy_framework/utils.py
@@ -117,7 +117,7 @@ def generate_market_slot_list(start_timestamp=None):
     """
     time_span = (
         GlobalConfig.slot_length
-        if GlobalConfig.is_canary_network()
+        if GlobalConfig.is_canary_network() and GlobalConfig.RUN_IN_REALTIME
         else min(GlobalConfig.sim_duration, duration(days=PROFILE_EXPANSION_DAYS))
     )
     time_span += duration(hours=ConstSettings.FutureMarketSettings.FUTURE_MARKET_DURATION_HOURS)


### PR DESCRIPTION
…ofiles. Moved RUN_IN_REALTIME constant to gsy-framework, in order to be taken into account by the generate_market_slot_list function.

## Reason for the proposed changes

Please describe what we want to achieve and why.

## Proposed changes

-

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**GSY_WEB_BRANCH**=master
